### PR TITLE
Update Q2 2026 quarterly meeting registration URL

### DIFF
--- a/public/data/quarterly_meetings.json
+++ b/public/data/quarterly_meetings.json
@@ -1,7 +1,7 @@
 {
   "nextDate": "2026-05-27",
   "time": "11:30 ET",
-  "registrationUrl": "https://events.teams.microsoft.com/event/7f521f38-4991-4772-8c5d-4d96f215c60c@bc633bf7-1766-4960-bc95-a16fdb861a57",
+  "registrationUrl": "https://events.teams.microsoft.com/event/25230b6c-2073-495c-b95f-b29cc766f3bc%40bc633bf7-1766-4960-bc95-a16fdb861a57",
   "meetingTitle": "Q2 2026 Collaborative Continuous Monitoring Review",
   "description": "Quarterly synchronous review of System 2.5 Ongoing Authorization data per FRR-CCM-QR-02.",
   "durationMinutes": 60


### PR DESCRIPTION
## Summary
Updated the registration URL for the Q2 2026 quarterly meeting to point to a new Microsoft Teams event.

## Changes
- Updated `registrationUrl` in `quarterly_meetings.json` to reflect the new Teams meeting event ID
- The URL now uses the encoded event ID `25230b6c-2073-495c-b95f-b29cc766f3bc%40bc633bf7-1766-4960-bc95-a16fdb861a57` (with `%40` representing the `@` symbol)

## Details
The meeting details remain unchanged:
- Date: May 27, 2026
- Time: 11:30 ET
- Title: Q2 2026 Collaborative Continuous Monitoring Review
- Duration: 60 minutes

https://claude.ai/code/session_01FcsvLNwryWxfrEpLVzuSLs