### PR TITLE
Use window.open for register button to fix @ URL parsing

### DIFF
--- a/public/data/quarterly_meetings.json
+++ b/public/data/quarterly_meetings.json
@@ -1,7 +1,7 @@
 {
   "nextDate": "2026-05-27",
   "time": "11:30 ET",
-  "registrationUrl": "https://events.teams.microsoft.com/event/25230b6c-2073-495c-b95f-b29cc766f3bc%40bc633bf7-1766-4960-bc95-a16fdb861a57",
+  "registrationUrl": "https://events.teams.microsoft.com/event/25230b6c-2073-495c-b95f-b29cc766f3bc@bc633bf7-1766-4960-bc95-a16fdb861a57",
   "meetingTitle": "Q2 2026 Collaborative Continuous Monitoring Review",
   "description": "Quarterly synchronous review of System 2.5 Ongoing Authorization data per FRR-CCM-QR-02.",
   "durationMinutes": 60

--- a/src/components/trust/ReportsHub.jsx
+++ b/src/components/trust/ReportsHub.jsx
@@ -322,10 +322,10 @@ const SchedulePanel = memo(({ manifest, meeting }) => {
 
             {meeting && (
                 <div className="space-y-1.5 mb-4">
-                    <a href={meeting.registrationUrl || '#'} target="_blank" rel="noreferrer"
-                       className="flex items-center justify-center gap-1.5 w-full py-2 bg-indigo-600 text-white rounded-lg font-bold text-[10px] hover:bg-indigo-500 transition-all">
+                    <button onClick={() => window.open(meeting.registrationUrl, '_blank', 'noopener')}
+                       className="flex items-center justify-center gap-1.5 w-full py-2 bg-indigo-600 text-white rounded-lg font-bold text-[10px] hover:bg-indigo-500 transition-all cursor-pointer">
                         <Video className="w-3 h-3" /> Register for Session
-                    </a>
+                    </button>
                     <button onClick={downloadICS}
                         className="flex items-center justify-center gap-1.5 w-full py-1.5 bg-white/5 text-slate-300 rounded-lg font-bold text-[9px] uppercase tracking-wider hover:bg-white/10 transition-all">
                         <Download className="w-3 h-3" /> Add to Calendar

--- a/src/components/trust/TrustCenterView.jsx
+++ b/src/components/trust/TrustCenterView.jsx
@@ -154,10 +154,10 @@ const QuarterlyReviewCard = ({ meeting }) => {
                         <FileText className="w-4 h-4" /> View Quarterly QAR 
                     </a>
 
-                    <a href={meeting.registrationUrl || '#'} target="_blank" rel="noreferrer"
-                        className="flex items-center justify-center gap-2 w-full py-2.5 bg-indigo-500 text-white rounded-2xl font-bold text-xs hover:bg-indigo-400 transition-all border border-indigo-400">
-                        <Video className="w-4 h-4" /> Register for Session 
-                    </a>
+                    <button onClick={() => window.open(meeting.registrationUrl, '_blank', 'noopener')}
+                        className="flex items-center justify-center gap-2 w-full py-2.5 bg-indigo-500 text-white rounded-2xl font-bold text-xs hover:bg-indigo-400 transition-all border border-indigo-400 cursor-pointer">
+                        <Video className="w-4 h-4" /> Register for Session
+                    </button>
 
                     <button onClick={downloadICS}
                         className="flex items-center justify-center gap-2 w-full py-2 bg-indigo-700/40 text-indigo-100 rounded-2xl font-bold text-[10px] uppercase tracking-widest hover:bg-indigo-700 transition-colors border border-indigo-400/20">


### PR DESCRIPTION
Browsers treat @ in <a href> URLs as a userinfo separator (anti-phishing feature), which strips the event path and redirects to the cancelled page. Switching to a button with window.open() bypasses this href URL parsing and navigates to the correct Teams event URL.

