### PR TITLE
Update Q1 2026 quarterly meeting registration URL

### DIFF
--- a/public/data/quarterly_meetings.json
+++ b/public/data/quarterly_meetings.json
@@ -1,7 +1,7 @@
 {
   "nextDate": "2026-02-18",
   "time": "14:00 ET",
-  "registrationUrl": "https://events.teams.microsoft.com/event/25230b6c-2073-495c-b95f-b29cc766f3bc@bc633bf7-1766-4960-bc95-a16fdb861a57",
+  "registrationUrl": "https://events.teams.microsoft.com/event/7f521f38-4991-4772-8c5d-4d96f215c60c@bc633bf7-1766-4960-bc95-a16fdb861a57",
   "meetingTitle": "Q1 2026 Collaborative Continuous Monitoring Review",
   "description": "Quarterly synchronous review of System 2.5 Ongoing Authorization data per FRR-CCM-QR-02.",
   "durationMinutes": 60


### PR DESCRIPTION
## Summary
Updated the Microsoft Teams meeting registration URL for the Q1 2026 quarterly collaborative continuous monitoring review.

## Changes
- Updated `registrationUrl` in `quarterly_meetings.json` to point to the new Teams event registration link
  - Previous event ID: `25230b6c-2073-495c-b95f-b29cc766f3bc`
  - New event ID: `7f521f38-4991-4772-8c5d-4d96f215c60c`
  - Meeting details (date, time, title, description) remain unchanged

## Details
The registration URL has been updated to reflect the correct Teams event for the Q1 2026 meeting scheduled for February 18, 2026 at 14:00 ET. The meeting will continue to serve as the quarterly synchronous review of System 2.5 Ongoing Authorization data per FRR-CCM-QR-02.

https://claude.ai/code/session_01FCffmnwp58kqg8NmBaWBac