### PR TITLE
Centralize quarterly registration URL to prevent pipeline overwrites

### DIFF
--- a/public/data/quarterly_meetings.json
+++ b/public/data/quarterly_meetings.json
@@ -1,7 +1,7 @@
 {
   "nextDate": "2026-02-18",
   "time": "14:00 ET",
-  "registrationUrl": "https://events.teams.microsoft.com/event/25230b6c-2073-495c-b95f-b29cc766f3bc@bc633bf7-1766-4960-bc95-a16fdb861a57",
+  "registrationUrl": "https://events.teams.microsoft.com/event/7f521f38-4991-4772-8c5d-4d96f215c60c@bc633bf7-1766-4960-bc95-a16fdb861a57",
   "meetingTitle": "Q1 2026 Collaborative Continuous Monitoring Review",
   "description": "Quarterly synchronous review of System 2.5 Ongoing Authorization data per FRR-CCM-QR-02.",
   "durationMinutes": 60

--- a/src/components/trust/ReportsHub.jsx
+++ b/src/components/trust/ReportsHub.jsx
@@ -7,6 +7,8 @@ import {
     Globe
 } from 'lucide-react';
 
+import { QUARTERLY_REGISTRATION_URL } from '../../config/api';
+
 // --- CONFIGURATION ---
 const BASE_PATH = import.meta.env.BASE_URL.endsWith('/')
     ? `${import.meta.env.BASE_URL}data/`
@@ -269,6 +271,9 @@ const SchedulePanel = memo(({ manifest, meeting }) => {
         ? new Date(generatedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
         : 'N/A';
 
+    // Use locally-maintained URL so pipeline data syncs cannot overwrite it
+    const registrationUrl = QUARTERLY_REGISTRATION_URL || meeting?.registrationUrl;
+
     const downloadICS = () => {
         if (!meeting) return;
         const ics = [
@@ -276,7 +281,7 @@ const SchedulePanel = memo(({ manifest, meeting }) => {
             `SUMMARY:${meeting.meetingTitle || 'FedRAMP Quarterly Review'}`,
             `DTSTART:${(meeting.nextDate || '').replace(/-/g, '')}T190000Z`,
             `DURATION:PT${meeting.durationMinutes || 60}M`,
-            `DESCRIPTION:${meeting.description || ''}\\n\\nRegister: ${meeting.registrationUrl}`,
+            `DESCRIPTION:${meeting.description || ''}\\n\\nRegister: ${registrationUrl}`,
             'END:VEVENT', 'END:VCALENDAR'
         ].join('\n');
         const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' });
@@ -322,7 +327,7 @@ const SchedulePanel = memo(({ manifest, meeting }) => {
 
             {meeting && (
                 <div className="space-y-1.5 mb-4">
-                    <button onClick={() => window.open(meeting.registrationUrl, '_blank', 'noopener')}
+                    <button onClick={() => window.open(registrationUrl, '_blank', 'noopener')}
                        className="flex items-center justify-center gap-1.5 w-full py-2 bg-indigo-600 text-white rounded-lg font-bold text-[10px] hover:bg-indigo-500 transition-all cursor-pointer">
                         <Video className="w-3 h-3" /> Register for Session
                     </button>

--- a/src/components/trust/TrustCenterView.jsx
+++ b/src/components/trust/TrustCenterView.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo, memo, useCallback } from 'react';
 import { useAuth } from '../../hooks/useAuth';
 import { useModal } from '../../contexts/ModalContext';
 import { useSystemStatus } from '../../hooks/useSystemStatus';
-import { API_CONFIG } from '../../config/api';
+import { API_CONFIG, QUARTERLY_REGISTRATION_URL } from '../../config/api';
 import {
     Shield, Download, FileText, ExternalLink,
     Clock, CheckCircle2, Mail, Globe, Lock, Server, Activity,
@@ -99,6 +99,9 @@ const PlannedChangesSection = ({ scnHistory }) => {
 const QuarterlyReviewCard = ({ meeting }) => {
     if (!meeting) return null;
 
+    // Use the locally-maintained URL so pipeline data syncs cannot overwrite it
+    const registrationUrl = QUARTERLY_REGISTRATION_URL || meeting.registrationUrl;
+
     // Dynamically resolve the path based on the environment BASE_URL to prevent GitHub Pages 404s
     const reportsPath = import.meta.env.BASE_URL.endsWith('/')
         ? `${import.meta.env.BASE_URL}reports/`
@@ -110,7 +113,7 @@ const QuarterlyReviewCard = ({ meeting }) => {
             `SUMMARY:${meeting.meetingTitle || 'FedRAMP Quarterly Review'}`,
             `DTSTART:${(meeting.nextDate || '').replace(/-/g, '')}T190000Z`,
             `DURATION:PT${meeting.durationMinutes || 60}M`,
-            `DESCRIPTION:${meeting.description || 'Synchronous review session.'}\\n\\nRegister: ${meeting.registrationUrl}`,
+            `DESCRIPTION:${meeting.description || 'Synchronous review session.'}\\n\\nRegister: ${registrationUrl}`,
             `LOCATION:Microsoft Teams (Registration Required)`,
             'END:VEVENT', 'END:VCALENDAR'
         ].join('\n');
@@ -154,7 +157,7 @@ const QuarterlyReviewCard = ({ meeting }) => {
                         <FileText className="w-4 h-4" /> View Quarterly QAR 
                     </a>
 
-                    <button onClick={() => window.open(meeting.registrationUrl, '_blank', 'noopener')}
+                    <button onClick={() => window.open(registrationUrl, '_blank', 'noopener')}
                         className="flex items-center justify-center gap-2 w-full py-2.5 bg-indigo-500 text-white rounded-2xl font-bold text-xs hover:bg-indigo-400 transition-all border border-indigo-400 cursor-pointer">
                         <Video className="w-4 h-4" /> Register for Session
                     </button>

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -36,6 +36,12 @@ export const API_CONFIG = {
     DEMO_MODE: false
 };
 
+// === QUARTERLY REVIEW SESSION ===
+// Canonical registration URL maintained here so pipeline data syncs cannot overwrite it.
+// Update this value whenever a new Teams event is created for the next quarterly session.
+export const QUARTERLY_REGISTRATION_URL =
+    'https://events.teams.microsoft.com/event/7f521f38-4991-4772-8c5d-4d96f215c60c@bc633bf7-1766-4960-bc95-a16fdb861a57';
+
 // === GITHUB RAW DATA CONFIGURATION ===
 // Used for fetching static assets directly from the repo
 const REPO_OWNER = 'Meridian-Knowledge-Solutions';


### PR DESCRIPTION
## Summary
This PR centralizes the quarterly review session registration URL in the application configuration to prevent pipeline data syncs from overwriting it with outdated values.

## Key Changes
- **New config export**: Added `QUARTERLY_REGISTRATION_URL` to `src/config/api.js` as the canonical source for the quarterly review registration link
- **Updated ReportsHub component**: Modified `SchedulePanel` to use the centralized URL with fallback to meeting data
- **Updated TrustCenterView component**: Modified `QuarterlyReviewCard` to use the centralized URL with fallback to meeting data
- **Updated quarterly meetings data**: Synced `public/data/quarterly_meetings.json` with the new Teams event URL

## Implementation Details
- The centralized URL takes precedence over the pipeline-synced data via a fallback pattern: `QUARTERLY_REGISTRATION_URL || meeting.registrationUrl`
- This ensures the registration link remains stable even when quarterly meeting data is refreshed from upstream sources
- Both the ICS calendar export and the registration button now use the centralized URL
- Added explanatory comments indicating this is intentional to prevent pipeline overwrites

https://claude.ai/code/session_01Q3vDhVJ5Sd4wXDQ8H2dQbq