### PR TITLE
Surface actual condition/failure reasons in Assessment Details modal

### DIFF
--- a/src/components/modals/WhyModal.jsx
+++ b/src/components/modals/WhyModal.jsx
@@ -6,6 +6,7 @@ import {
   parseKsiValidation,
   generateCriteriaText,
 } from '../../utils/ksiValidationParser';
+import { Sanitizer } from '../../utils/sanitizer';
 import {
   AlertTriangle, CheckCircle, Info, FileText, Terminal, Shield,
   ChevronDown, ChevronRight, Database, Cpu, Lock, Layers,
@@ -210,6 +211,32 @@ export const WhyModal = () => {
             </div>
           </div>
 
+          {/* Condition/Failure reason — public-safe summary of why this status */}
+          {parsed.status !== 'passed' && parsed.assertionReason && (
+            <div className={`p-4 rounded-xl border ${
+              parsed.status === 'warning' ? 'border-amber-500/20 bg-amber-500/5' :
+              parsed.status === 'failed' ? 'border-red-500/20 bg-red-500/5' :
+              'border-blue-500/20 bg-blue-500/5'
+            }`}>
+              <div className="flex items-start gap-3">
+                <AlertCircle size={18} className={`mt-0.5 flex-shrink-0 ${
+                  parsed.status === 'warning' ? 'text-amber-400' :
+                  parsed.status === 'failed' ? 'text-red-400' : 'text-blue-400'
+                }`} />
+                <div>
+                  <h4 className={`font-semibold text-sm mb-1 ${
+                    parsed.status === 'warning' ? 'text-amber-300' :
+                    parsed.status === 'failed' ? 'text-red-300' : 'text-blue-300'
+                  }`}>
+                    {parsed.status === 'warning' ? 'Condition Details' :
+                     parsed.status === 'failed' ? 'Failure Details' : 'Details'}
+                  </h4>
+                  <p className="text-sm text-gray-300 leading-relaxed">{Sanitizer.sanitizeReason(parsed.assertionReason)}</p>
+                </div>
+              </div>
+            </div>
+          )}
+
           {/* Implementation Summary - visible to agencies before login */}
           {data.implementation_summary && (
             <div className="p-4 rounded-xl border border-blue-500/20 bg-blue-500/5">
@@ -284,6 +311,50 @@ export const WhyModal = () => {
             </div>
           </div>
         </div>
+
+        {/* Condition / Failure Reason — explains WHY this control has its status */}
+        {parsed.status !== 'passed' && parsed.assertionReason && (
+          <div className={`p-4 rounded-xl border ${
+            parsed.status === 'warning' ? 'border-amber-500/30 bg-amber-500/5' :
+            parsed.status === 'failed' ? 'border-red-500/30 bg-red-500/5' :
+            'border-blue-500/30 bg-blue-500/5'
+          }`}>
+            <div className="flex items-start gap-3">
+              <AlertCircle size={18} className={`mt-0.5 flex-shrink-0 ${
+                parsed.status === 'warning' ? 'text-amber-400' :
+                parsed.status === 'failed' ? 'text-red-400' : 'text-blue-400'
+              }`} />
+              <div>
+                <h4 className={`font-semibold text-sm mb-2 ${
+                  parsed.status === 'warning' ? 'text-amber-300' :
+                  parsed.status === 'failed' ? 'text-red-300' : 'text-blue-300'
+                }`}>
+                  {parsed.status === 'warning' ? 'Why This Control Is Conditional' :
+                   parsed.status === 'failed' ? 'Why This Control Failed' : 'Additional Context'}
+                </h4>
+                <p className="text-sm text-gray-300 leading-relaxed">{parsed.assertionReason}</p>
+                {parsed.reasonParsed.details.length > 1 && (
+                  <ul className="mt-3 space-y-1.5">
+                    {parsed.reasonParsed.details.map((detail, idx) => (
+                      <li key={idx} className="flex items-start gap-2 text-sm text-gray-400">
+                        <span className={`mt-1.5 w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+                          detail.includes('✅') || detail.toLowerCase().includes('pass') || detail.toLowerCase().includes('verified')
+                            ? 'bg-green-500'
+                            : detail.includes('❌') || detail.toLowerCase().includes('fail')
+                              ? 'bg-red-500'
+                              : detail.includes('⚠') || detail.toLowerCase().includes('warning')
+                                ? 'bg-amber-500'
+                                : 'bg-gray-500'
+                        }`} />
+                        <span>{detail}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Category & Requirement */}
         <div className="p-4 rounded-xl border border-gray-700/50 bg-gray-900/50">

--- a/src/utils/ksiValidationParser.js
+++ b/src/utils/ksiValidationParser.js
@@ -275,10 +275,11 @@ export const parseKsiValidation = (ksi) => {
     requirement: ksi.requirement || ksi.description,
     longName: ksi.long_name,
     
-    // Status
+    // Status — preserve the pre-computed status (from Sanitizer) if available,
+    // since it distinguishes warning/info from simple pass/fail
     assertion: ksi.assertion,
     score: ksi.score ?? reasonParsed.score,
-    status: ksi.assertion ? 'passed' : 'failed',
+    status: ksi.status || (ksi.assertion ? 'passed' : 'failed'),
     statusLabel: reasonParsed.label,
     
     // Resources


### PR DESCRIPTION
The WhyModal said "Compliant with Conditions" but never showed what the actual conditions were. Now:

- Parser preserves the warning/info status from Sanitizer instead of collapsing to binary pass/fail
- Authenticated view shows a prominent "Why This Control Is Conditional" section with the assertion_reason text and parsed detail bullets
- Public view shows sanitized condition/failure details so agencies can understand the status without needing to log in
- Both views use color-coded callouts matching the status severity

https://claude.ai/code/session_018BYL1Te66ScPp3MkaX9qGu