### PR TITLE
Claude/add organization tabs mk efx

### DIFF
--- a/src/components/modals/WhyModal.jsx
+++ b/src/components/modals/WhyModal.jsx
@@ -156,6 +156,85 @@ const ServiceGroupCard = ({ group }) => {
   );
 };
 
+// Structured finding row — renders a single parsed finding as a clean line item
+const FindingItem = ({ finding, compact = false }) => {
+  const statusStyles = {
+    pass: { icon: CheckCircle, color: 'text-green-400', bg: 'bg-green-500/10', border: 'border-green-500/20' },
+    fail: { icon: AlertTriangle, color: 'text-red-400', bg: 'bg-red-500/10', border: 'border-red-500/20' },
+    warning: { icon: AlertTriangle, color: 'text-amber-400', bg: 'bg-amber-500/10', border: 'border-amber-500/20' },
+    info: { icon: Info, color: 'text-blue-400', bg: 'bg-blue-500/10', border: 'border-blue-500/20' },
+  };
+  const style = statusStyles[finding.status] || statusStyles.info;
+  const Icon = style.icon;
+
+  if (compact) {
+    return (
+      <div className="flex items-start gap-2 py-1">
+        <Icon size={14} className={`mt-0.5 flex-shrink-0 ${style.color}`} />
+        <span className="text-sm text-gray-300 leading-snug">
+          {finding.category && (
+            <span className="font-medium text-gray-200">{finding.category}: </span>
+          )}
+          {finding.message}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`flex items-start gap-3 p-3 rounded-lg border ${style.border} ${style.bg}`}>
+      <Icon size={16} className={`mt-0.5 flex-shrink-0 ${style.color}`} />
+      <div className="flex-1 min-w-0">
+        {finding.category && (
+          <span className="text-[10px] font-bold uppercase tracking-wider text-gray-400 block mb-0.5">{finding.category}</span>
+        )}
+        <p className="text-sm text-gray-200 leading-relaxed">{finding.message}</p>
+      </div>
+    </div>
+  );
+};
+
+// Findings list — groups and presents structured findings intelligently
+const FindingsList = ({ findings, maxVisible = 4, compact = false }) => {
+  const [showAll, setShowAll] = useState(false);
+
+  if (!findings || findings.length === 0) return null;
+
+  // Separate by status: show conditions/failures prominently, collapse passing items
+  const conditions = findings.filter(f => f.status === 'warning' || f.status === 'info');
+  const failures = findings.filter(f => f.status === 'fail');
+  const passes = findings.filter(f => f.status === 'pass');
+
+  // Prioritized order: failures first, then conditions, then passes
+  const prioritized = [...failures, ...conditions, ...passes];
+  const visible = showAll ? prioritized : prioritized.slice(0, maxVisible);
+  const hiddenCount = prioritized.length - maxVisible;
+
+  return (
+    <div className="space-y-2">
+      {visible.map((finding, idx) => (
+        <FindingItem key={idx} finding={finding} compact={compact} />
+      ))}
+      {!showAll && hiddenCount > 0 && (
+        <button
+          onClick={() => setShowAll(true)}
+          className="text-xs text-blue-400 hover:text-blue-300 font-medium transition-colors pl-1"
+        >
+          Show {hiddenCount} more finding{hiddenCount !== 1 ? 's' : ''}
+        </button>
+      )}
+      {showAll && hiddenCount > 0 && (
+        <button
+          onClick={() => setShowAll(false)}
+          className="text-xs text-gray-500 hover:text-gray-300 font-medium transition-colors pl-1"
+        >
+          Show less
+        </button>
+      )}
+    </div>
+  );
+};
+
 export const WhyModal = () => {
   const { modals, closeModal, openModal } = useModal();
   const { isAuthenticated } = useAuth();
@@ -211,15 +290,15 @@ export const WhyModal = () => {
             </div>
           </div>
 
-          {/* Condition note — clean extracted message for warning-status controls */}
-          {parsed.status === 'warning' && parsed.conditionMessage && (
-            <div className="p-4 rounded-xl border border-amber-500/20 bg-amber-500/5">
-              <div className="flex items-start gap-3">
-                <AlertTriangle size={18} className="mt-0.5 flex-shrink-0 text-amber-400" />
-                <p className="text-sm text-gray-300 leading-relaxed">
-                  {Sanitizer.sanitizeReason(parsed.conditionMessage)}
-                </p>
-              </div>
+          {/* Structured condition findings for warning-status controls (public view) */}
+          {parsed.status === 'warning' && parsed.conditionMessages.length > 0 && (
+            <div className="p-4 rounded-xl border border-amber-500/20 bg-amber-500/5 space-y-2">
+              {parsed.conditionMessages.map((f, idx) => (
+                <FindingItem key={idx} finding={{
+                  ...f,
+                  message: Sanitizer.sanitizeReason(f.message),
+                }} compact />
+              ))}
             </div>
           )}
 
@@ -298,16 +377,26 @@ export const WhyModal = () => {
           </div>
         </div>
 
-        {/* Condition note — clean extracted message for warning-status controls */}
-        {parsed.status === 'warning' && parsed.conditionMessage && (
-          <div className="p-4 rounded-xl border border-amber-500/30 bg-amber-500/5">
-            <div className="flex items-start gap-3">
-              <AlertTriangle size={18} className="mt-0.5 flex-shrink-0 text-amber-400" />
-              <p className="text-sm text-gray-300 leading-relaxed">
-                {parsed.conditionMessage}
-              </p>
-            </div>
-          </div>
+        {/* Structured findings — all parsed items from assertion_reason */}
+        {parsed.structuredFindings.length > 0 && (
+          <CollapsibleSection
+            title="Assessment Findings"
+            icon={Eye}
+            defaultOpen={parsed.status !== 'passed'}
+            badge={(() => {
+              const fails = parsed.structuredFindings.filter(f => f.status === 'fail').length;
+              const warns = parsed.structuredFindings.filter(f => f.status === 'warning').length;
+              if (fails > 0) return `${fails} issue${fails !== 1 ? 's' : ''}`;
+              if (warns > 0) return `${warns} condition${warns !== 1 ? 's' : ''}`;
+              return `${parsed.structuredFindings.length} checked`;
+            })()}
+            badgeColor={
+              parsed.structuredFindings.some(f => f.status === 'fail') ? 'red' :
+              parsed.structuredFindings.some(f => f.status === 'warning') ? 'yellow' : 'green'
+            }
+          >
+            <FindingsList findings={parsed.structuredFindings} maxVisible={5} />
+          </CollapsibleSection>
         )}
 
         {/* Category & Requirement */}

--- a/src/components/modals/WhyModal.jsx
+++ b/src/components/modals/WhyModal.jsx
@@ -211,13 +211,13 @@ export const WhyModal = () => {
             </div>
           </div>
 
-          {/* Warnings — simple reason text for non-passing controls */}
-          {parsed.status === 'warning' && parsed.assertionReason && (
+          {/* Condition note — clean extracted message for warning-status controls */}
+          {parsed.status === 'warning' && parsed.conditionMessage && (
             <div className="p-4 rounded-xl border border-amber-500/20 bg-amber-500/5">
               <div className="flex items-start gap-3">
                 <AlertTriangle size={18} className="mt-0.5 flex-shrink-0 text-amber-400" />
                 <p className="text-sm text-gray-300 leading-relaxed">
-                  {Sanitizer.sanitizeReason(parsed.assertionReason)}
+                  {Sanitizer.sanitizeReason(parsed.conditionMessage)}
                 </p>
               </div>
             </div>
@@ -298,13 +298,13 @@ export const WhyModal = () => {
           </div>
         </div>
 
-        {/* Warnings — simple reason text for warning-status controls */}
-        {parsed.status === 'warning' && parsed.assertionReason && (
+        {/* Condition note — clean extracted message for warning-status controls */}
+        {parsed.status === 'warning' && parsed.conditionMessage && (
           <div className="p-4 rounded-xl border border-amber-500/30 bg-amber-500/5">
             <div className="flex items-start gap-3">
               <AlertTriangle size={18} className="mt-0.5 flex-shrink-0 text-amber-400" />
               <p className="text-sm text-gray-300 leading-relaxed">
-                {parsed.assertionReason}
+                {parsed.conditionMessage}
               </p>
             </div>
           </div>

--- a/src/utils/ksiValidationParser.js
+++ b/src/utils/ksiValidationParser.js
@@ -103,6 +103,71 @@ export const extractServiceFromCommand = (command) => {
 };
 
 /**
+ * Parse individual findings from the assertion_reason into structured items.
+ *
+ * Handles formats like:
+ *   "✅ Excellent 10/10 (100%): ✅ [Technical] Inspector active.; ❌ [Evidence] No issues found."
+ *   "Good (85%): ... | 6/7 resources compliant. | Verified: Compliant: SG ... | Warnings: Best Practice: ..."
+ *
+ * Returns an array of { status: 'pass'|'fail'|'warning'|'info', category: string, message: string }
+ */
+export const parseStructuredFindings = (reason) => {
+  if (!reason) return [];
+
+  // Strip the leading headline/score prefix (everything before the first finding emoji or bracket)
+  // e.g. "✅ Excellent 10/10 (100%): ✅ [Technical] ..." → start at the findings
+  let body = reason;
+  const headerCut = body.match(/^[^:]*\(\d+%\)\s*:\s*/);
+  if (headerCut) {
+    body = body.slice(headerCut[0].length);
+  }
+
+  // Split on semicolons or pipes (the two common delimiters)
+  const rawSegments = body.split(/[;|]/).map(s => s.trim()).filter(s => s.length > 0);
+
+  const results = [];
+  for (const seg of rawSegments) {
+    // Skip noise segments
+    const lower = seg.toLowerCase();
+    if (lower.match(/^\d+\/\d+\s+resources?\s+compliant/)) continue;
+    if (lower.match(/^\.\.\.and\s+\d+\s+more/)) continue;
+    if (lower.match(/^verified:\s*$/)) continue;
+
+    // Determine status from leading emoji
+    let status = 'info';
+    let cleaned = seg;
+    if (seg.startsWith('✅')) { status = 'pass'; cleaned = seg.replace(/^✅\s*/, ''); }
+    else if (seg.startsWith('❌')) { status = 'fail'; cleaned = seg.replace(/^❌\s*/, ''); }
+    else if (seg.startsWith('⚠️')) { status = 'warning'; cleaned = seg.replace(/^⚠️\s*/, ''); }
+    else if (seg.startsWith('ℹ️')) { status = 'info'; cleaned = seg.replace(/^ℹ️\s*/, ''); }
+    // Also detect via keywords when no emoji present
+    else if (lower.startsWith('warnings:') || lower.startsWith('warning:') || lower.startsWith('best practice:')) {
+      status = 'warning';
+      cleaned = seg.replace(/^Warnings:\s*/i, '');
+    }
+    else if (lower.startsWith('verified:') || lower.startsWith('compliant:')) {
+      status = 'pass';
+    }
+
+    // Extract [Category] tag if present
+    let category = '';
+    const catMatch = cleaned.match(/^\[([^\]]+)\]\s*/);
+    if (catMatch) {
+      category = catMatch[1];
+      cleaned = cleaned.slice(catMatch[0].length);
+    }
+
+    // Skip empty or pure-noise leftovers
+    const trimmed = cleaned.replace(/[✅❌⚠️ℹ️]/g, '').trim();
+    if (!trimmed || trimmed.length < 3) continue;
+
+    results.push({ status, category, message: trimmed });
+  }
+
+  return results;
+};
+
+/**
  * Parse assertion_reason to extract structured findings
  * Example: "✅ Excellent (100%): 3 items: 3 verified"
  * Example: "❌ Insufficient (60%): 5 items: 3 verified, 2 failed"
@@ -149,30 +214,8 @@ export const parseAssertionReason = (reason) => {
   // Split by semicolons or bullets for detailed findings
   const parts = reason.split(/[;•]/).map(s => s.trim()).filter(s => s.length > 0);
   
-  // Extract a clean, short condition/warning message (strip the verbose pipe-delimited noise)
-  let conditionMessage = '';
-  if (reason.includes('|')) {
-    const segments = reason.split('|').map(s => s.trim());
-    // Look for the segment that starts with a meaningful condition (e.g. "Best Practice:", "Warning:")
-    // Skip segments that are just status labels, resource counts, or verification lists
-    for (const seg of segments) {
-      const lower = seg.toLowerCase();
-      // Skip status/score prefix like "Good (85%): ..."
-      if (lower.match(/^(✅|❌|⚠️|ℹ️)?\s*(excellent|good|insufficient|critical|technical failure)/)) continue;
-      // Skip resource compliance counts like "6/7 resources compliant"
-      if (lower.match(/^\d+\/\d+\s+resources?\s+compliant/)) continue;
-      // Skip verification lists like "Verified: Compliant: SG..."
-      if (lower.match(/^verified:/)) continue;
-      // Skip "...and N more" summaries
-      if (lower.match(/^\.\.\.and\s+\d+\s+more/)) continue;
-      // Skip "Warnings:" prefix but keep what follows
-      const warningStripped = seg.replace(/^Warnings:\s*/i, '').trim();
-      if (warningStripped) {
-        conditionMessage = warningStripped;
-        break;
-      }
-    }
-  }
+  // Parse individual structured findings from the semicolon/pipe-separated reason text
+  const structuredFindings = parseStructuredFindings(reason);
 
   return {
     status: hasPass && !hasFail ? 'pass' : hasFail ? 'fail' : 'unknown',
@@ -180,7 +223,9 @@ export const parseAssertionReason = (reason) => {
     score,
     findings,
     details: parts,
-    conditionMessage,
+    structuredFindings,
+    // Convenience: condition messages are the warning/info findings
+    conditionMessages: structuredFindings.filter(f => f.status === 'warning' || f.status === 'info'),
   };
 };
 
@@ -321,8 +366,9 @@ export const parseKsiValidation = (ksi) => {
     checksSummary: outcomeSummary,
     serviceGroups,
     
-    // Clean condition message (extracted from verbose assertion_reason)
-    conditionMessage: reasonParsed.conditionMessage || '',
+    // Structured findings parsed from assertion_reason
+    structuredFindings: reasonParsed.structuredFindings || [],
+    conditionMessages: reasonParsed.conditionMessages || [],
 
     // Raw data for fallback
     assertionReason: ksi.assertion_reason,
@@ -369,6 +415,7 @@ export const generateCriteriaText = (parsed) => {
 
 export default {
   extractServiceFromCommand,
+  parseStructuredFindings,
   parseAssertionReason,
   parseCommandExecutions,
   getKsiCategory,

--- a/src/utils/ksiValidationParser.js
+++ b/src/utils/ksiValidationParser.js
@@ -149,12 +149,38 @@ export const parseAssertionReason = (reason) => {
   // Split by semicolons or bullets for detailed findings
   const parts = reason.split(/[;•]/).map(s => s.trim()).filter(s => s.length > 0);
   
+  // Extract a clean, short condition/warning message (strip the verbose pipe-delimited noise)
+  let conditionMessage = '';
+  if (reason.includes('|')) {
+    const segments = reason.split('|').map(s => s.trim());
+    // Look for the segment that starts with a meaningful condition (e.g. "Best Practice:", "Warning:")
+    // Skip segments that are just status labels, resource counts, or verification lists
+    for (const seg of segments) {
+      const lower = seg.toLowerCase();
+      // Skip status/score prefix like "Good (85%): ..."
+      if (lower.match(/^(✅|❌|⚠️|ℹ️)?\s*(excellent|good|insufficient|critical|technical failure)/)) continue;
+      // Skip resource compliance counts like "6/7 resources compliant"
+      if (lower.match(/^\d+\/\d+\s+resources?\s+compliant/)) continue;
+      // Skip verification lists like "Verified: Compliant: SG..."
+      if (lower.match(/^verified:/)) continue;
+      // Skip "...and N more" summaries
+      if (lower.match(/^\.\.\.and\s+\d+\s+more/)) continue;
+      // Skip "Warnings:" prefix but keep what follows
+      const warningStripped = seg.replace(/^Warnings:\s*/i, '').trim();
+      if (warningStripped) {
+        conditionMessage = warningStripped;
+        break;
+      }
+    }
+  }
+
   return {
     status: hasPass && !hasFail ? 'pass' : hasFail ? 'fail' : 'unknown',
     label,
     score,
     findings,
     details: parts,
+    conditionMessage,
   };
 };
 
@@ -295,6 +321,9 @@ export const parseKsiValidation = (ksi) => {
     checksSummary: outcomeSummary,
     serviceGroups,
     
+    // Clean condition message (extracted from verbose assertion_reason)
+    conditionMessage: reasonParsed.conditionMessage || '',
+
     // Raw data for fallback
     assertionReason: ksi.assertion_reason,
     recommendedAction: ksi.recommended_action,


### PR DESCRIPTION
Parser (parseStructuredFindings):

- Strips the score headline (✅ Excellent 10/10 (100%):)
- Splits on ; and | delimiters
- Detects status from emojis (✅/❌/⚠️/ℹ️) or keywords (Warnings:, Best Practice:, Verified:)
- Extracts [Category] tags (e.g. [Technical], [Documentation], [KMS Infrastructure])
- Filters out noise segments (resource counts, "...and N more", empty segments)
- Returns clean { status, category, message } items

Authenticated view — "Assessment Findings" collapsible section:

- Color-coded cards: green for pass, red for fail, amber for warning, blue for info
- Category label as a small uppercase tag above the message
- Smart badge on the section header: "2 issues", "1 condition", or "14 checked"
- Prioritized order: failures → conditions → passes
- Show more/less toggle (first 5 visible, expandable)
- Auto-opens for non-passing controls, collapsed for passing ones

Public view:

- Compact inline items with icon + category + sanitized message
- No raw text dump, just clean individual condition lines