### PR TITLE
Reorder view routing to prioritize trust center check

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -793,6 +793,7 @@ const AppShell = () => {
 
           <div className="p-4 sm:p-6 lg:p-8 max-w-[1600px] mx-auto relative z-10">
             {activeView === 'dashboard' ? <DashboardContent /> :
+              activeView === 'trust' ? <TrustCenterView /> :
               !isAuthenticated ? (
                 <div className="flex items-center justify-center min-h-[60vh]">
                   <div className="bg-gradient-to-br from-gray-900 to-gray-800 p-10 rounded-2xl border border-gray-700 text-center max-w-md">
@@ -812,7 +813,6 @@ const AppShell = () => {
                   </div>
                 </div>
               ) :
-              activeView === 'trust' ? <TrustCenterView /> :
                 activeView === 'vdr' ? <VDRPublicMetricsDashboard /> :
                   activeView === 'transparency' ? <TransparencyConsole /> :
                     activeView === 'metrics' ? <MetricsDashboard /> :


### PR DESCRIPTION
## Summary
Reorganized the conditional rendering logic in the AppShell component to check for the 'trust' view earlier in the routing chain, moving it before the authentication check.

## Key Changes
- Moved the `activeView === 'trust'` condition from after the authentication check to immediately after the dashboard check
- This ensures the TrustCenterView is rendered without requiring authentication, allowing unauthenticated users to access the trust center

## Implementation Details
The change reorders the view routing priority so that:
1. Dashboard view is checked first
2. Trust center view is checked second (now accessible without authentication)
3. Authentication requirement is checked third
4. Other views (VDR, Transparency, Metrics, etc.) follow

This modification allows the trust center to be publicly accessible while maintaining authentication requirements for other views.

https://claude.ai/code/session_01LH9eLNVg8x39QavxC6DEki