### PR TITLE
Add support for "meets_threshold" validation status

### DIFF
--- a/src/components/findings/KSIGrid.jsx
+++ b/src/components/findings/KSIGrid.jsx
@@ -197,6 +197,7 @@ const KSICard = ({ ksi, openModal }) => {
   // Dark Theme Mapping
   const colors = {
     'passed': { border: 'border-green-500', text: 'text-green-400', bg: 'bg-green-500/10' },
+    'meets_threshold': { border: 'border-emerald-500', text: 'text-emerald-400', bg: 'bg-emerald-500/10' },
     'failed': { border: 'border-red-500', text: 'text-red-400', bg: 'bg-red-500/10' },
     'warning': { border: 'border-yellow-500', text: 'text-yellow-400', bg: 'bg-yellow-500/10' },
     'info': { border: 'border-blue-500', text: 'text-blue-400', bg: 'bg-blue-500/10' }

--- a/src/components/modals/WhyModal.jsx
+++ b/src/components/modals/WhyModal.jsx
@@ -256,6 +256,7 @@ export const WhyModal = () => {
   // Status configuration
   const statusConfig = {
     passed: { color: 'text-green-400', bg: 'bg-green-500/10', border: 'border-green-500/20', icon: CheckCircle },
+    meets_threshold: { color: 'text-emerald-400', bg: 'bg-emerald-500/10', border: 'border-emerald-500/20', icon: CheckCircle },
     failed: { color: 'text-red-400', bg: 'bg-red-500/10', border: 'border-red-500/20', icon: AlertTriangle },
     warning: { color: 'text-yellow-400', bg: 'bg-yellow-500/10', border: 'border-yellow-500/20', icon: Info },
     info: { color: 'text-blue-400', bg: 'bg-blue-500/10', border: 'border-blue-500/20', icon: Info }
@@ -275,12 +276,14 @@ export const WhyModal = () => {
               <StatusIcon className={`mt-1 ${config.color}`} size={24} />
               <div>
                 <h4 className={`font-bold ${config.color} mb-2 uppercase tracking-wide text-base`}>
-                  {parsed.status === 'passed' ? 'Compliant' :
+                  {parsed.status === 'passed' ? 'Operational' :
+                   parsed.status === 'meets_threshold' ? 'Meets Threshold' :
                    parsed.status === 'warning' ? 'Compliant with Conditions' :
                    parsed.status === 'failed' ? 'Remediation Required' : 'Attention Required'}
                 </h4>
                 <p className="text-sm text-gray-200">
                   {parsed.status === 'passed' && 'This control fully meets FedRAMP requirements. No action needed.'}
+                  {parsed.status === 'meets_threshold' && 'This control meets FedRAMP threshold requirements. No action needed.'}
                   {parsed.status === 'warning' && 'This control passes validation but has conditions or constraints that require ongoing monitoring. No immediate remediation is needed.'}
                   {parsed.status === 'failed' && 'This control failed validation and requires corrective action per FedRAMP remediation timelines.'}
                   {parsed.status === 'info' && 'This provides supplementary context about the control. No action required.'}
@@ -320,7 +323,7 @@ export const WhyModal = () => {
               <div className="text-xs font-bold uppercase text-gray-400 tracking-wider mb-2">Status</div>
               <div className={`font-bold text-xl flex items-center gap-2 ${config.color}`}>
                 <StatusIcon size={20} />
-                {parsed.status === 'warning' ? 'Conditional' : (parsed.statusLabel || parsed.status.toUpperCase())}
+                {parsed.status === 'warning' ? 'Conditional' : parsed.status === 'meets_threshold' ? 'Meets Threshold' : (parsed.statusLabel || parsed.status.toUpperCase())}
               </div>
               {parsed.status === 'warning' && (
                 <p className="text-xs text-gray-400 mt-2">Passes with conditions requiring monitoring</p>
@@ -336,7 +339,7 @@ export const WhyModal = () => {
               <div className="font-semibold text-white text-lg">{parsed.score}%</div>
               <div className="mt-2 h-1.5 bg-gray-700 rounded-full overflow-hidden">
                 <div 
-                  className={`h-full rounded-full ${parsed.score >= 80 ? 'bg-green-500' : parsed.score >= 50 ? 'bg-yellow-500' : 'bg-red-500'}`}
+                  className={`h-full rounded-full ${parsed.status === 'failed' ? 'bg-red-500' : parsed.status === 'meets_threshold' ? 'bg-emerald-500' : 'bg-green-500'}`}
                   style={{ width: `${parsed.score}%` }}
                 />
               </div>

--- a/src/components/trust/TransparencyConsole.jsx
+++ b/src/components/trust/TransparencyConsole.jsx
@@ -209,7 +209,7 @@ const ValidationCard = ({ validation }) => {
                     <div className="flex items-center gap-2">
                         <div className="flex-1 h-1.5 bg-zinc-800 rounded-full overflow-hidden max-w-[80px]">
                             <div 
-                                className={`h-full rounded-full ${validation.score >= 80 ? 'bg-emerald-500' : validation.score >= 50 ? 'bg-amber-500' : 'bg-red-500'}`}
+                                className={`h-full rounded-full ${validation.display_status === 'fail' ? 'bg-red-500' : 'bg-emerald-500'}`}
                                 style={{ width: `${validation.score}%` }}
                             />
                         </div>

--- a/src/hooks/useData.jsx
+++ b/src/hooks/useData.jsx
@@ -28,7 +28,7 @@ export const DataProvider = ({ children }) => {
   const [masData, setMasData] = useState(null);
   const [metricsData, setMetricsData] = useState(null);
   const [metrics, setMetrics] = useState({
-    score: 0, passed: 0, failed: 0, warning: 0, info: 0
+    score: 0, passed: 0, failed: 0, meets_threshold: 0, warning: 0, info: 0
   });
 
   const previousScore = useRef(null);
@@ -355,6 +355,7 @@ export const DataProvider = ({ children }) => {
         score: score,
         passed: passedCount,
         failed: failedCount,
+        meets_threshold: processed.filter(k => k.status === 'meets_threshold').length,
         warning: processed.filter(k => k.status === 'warning').length,
         info: processed.filter(k => k.status === 'info').length
       });

--- a/src/utils/ksiValidationParser.js
+++ b/src/utils/ksiValidationParser.js
@@ -351,6 +351,7 @@ export const parseKsiValidation = (ksi) => {
     assertion: ksi.assertion,
     score: ksi.score ?? reasonParsed.score,
     status: ksi.status || (ksi.assertion ? 'passed' : 'failed'),
+    displayStatus: ksi.display_status || null,
     statusLabel: reasonParsed.label,
     
     // Resources

--- a/src/utils/sanitizer.js
+++ b/src/utils/sanitizer.js
@@ -4,6 +4,15 @@ export const Sanitizer = {
         // Handle missing data gracefully
         if (!validation) return 'unknown';
 
+        // Priority 1: Use display_status from pipeline if available
+        if (validation.display_status) {
+            const ds = validation.display_status.toLowerCase();
+            if (ds === 'pass') return 'passed';
+            if (ds === 'meets_threshold') return 'meets_threshold';
+            if (ds === 'fail') return 'failed';
+        }
+
+        // Priority 2: Fall back to assertion-based logic
         const assertion = validation.assertion;
         const reason = validation.assertion_reason || validation.message || '';
 
@@ -33,7 +42,8 @@ export const Sanitizer = {
     // Used by the Grid to determine colors/icons
     mapStatus: (status) => {
         const map = {
-            'passed': { label: 'Compliant', icon: 'CheckCircle2', color: 'text-green-600', bg: 'bg-green-50', description: 'Control fully meets FedRAMP requirements' },
+            'passed': { label: 'Operational', icon: 'CheckCircle2', color: 'text-green-600', bg: 'bg-green-50', description: 'Control fully meets FedRAMP requirements' },
+            'meets_threshold': { label: 'Meets Threshold', icon: 'CheckCircle2', color: 'text-emerald-600', bg: 'bg-emerald-50', description: 'Control meets FedRAMP threshold requirements' },
             'failed': { label: 'Remediation Required', icon: 'XCircle', color: 'text-red-600', bg: 'bg-red-50', description: 'Control failed validation and requires corrective action' },
             'warning': { label: 'Compliant with Conditions', icon: 'AlertTriangle', color: 'text-amber-600', bg: 'bg-amber-50', description: 'Control passes but has conditions or constraints that require ongoing monitoring' },
             'info': { label: 'Informational', icon: 'Info', color: 'text-blue-600', bg: 'bg-blue-50', description: 'Supplementary context — no action required' },


### PR DESCRIPTION
## Summary
This PR introduces a new validation status level called "meets_threshold" to distinguish controls that meet FedRAMP threshold requirements from those that fully meet all requirements. This provides more granular status reporting and better aligns with FedRAMP compliance assessment practices.

## Key Changes

- **Sanitizer Logic**: Added priority-based status resolution that checks `display_status` from the pipeline first before falling back to assertion-based logic. The `display_status` field now supports three values: 'pass' → 'passed', 'meets_threshold' → 'meets_threshold', and 'fail' → 'failed'.

- **Status Mapping**: Updated `mapStatus()` to include the new 'meets_threshold' status with:
  - Label: "Meets Threshold"
  - Icon: CheckCircle2 (same as passed)
  - Color: emerald-600 (distinct from green-600 for passed)
  - Description: "Control meets FedRAMP threshold requirements"

- **UI Components**: Added visual styling for the new status across multiple components:
  - WhyModal: Added emerald color scheme and conditional text rendering
  - KSIGrid: Added emerald border/text/background colors
  - TransparencyConsole: Updated progress bar logic to use `display_status` field

- **Metrics Tracking**: Extended the metrics object to track `meets_threshold` count alongside existing status counts (passed, failed, warning, info)

- **Data Parser**: Updated `ksiValidationParser.js` to capture and expose the `displayStatus` field from validation data

## Implementation Details

The status resolution now follows a clear priority:
1. First checks for `display_status` from the pipeline (new)
2. Falls back to assertion-based logic (existing)

This allows the backend to explicitly control status classification while maintaining backward compatibility with assertion-based determination. The emerald color palette was chosen to visually distinguish "meets threshold" from "fully passed" while maintaining the positive connotation of both statuses.

https://claude.ai/code/session_013iu1XzQr7jK3wWDqRgr3CJ