### PR TITLE
Redesign trust center presentation layer for display_status pipeline

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -397,7 +397,7 @@ const DashboardContent = memo(() => {
   }[globalStatus] || { label: 'Unknown', color: 'text-slate-400', bg: 'bg-slate-500/10', border: 'border-slate-500/20', dot: 'bg-slate-500', solid: 'bg-slate-500' };
 
   const lastRunDate = metadata?.validation_date ? new Date(metadata.validation_date) : null;
-  const controlsAtRisk = parseInt(metrics.failed) + parseInt(metrics.meets_threshold || 0) + parseInt(metrics.warning || 0);
+  const failedCount = parseInt(metrics.failed);
 
   return (
     <div className="space-y-6 animate-in fade-in duration-500 slide-in-from-bottom-4">
@@ -433,8 +433,8 @@ const DashboardContent = memo(() => {
               <div className="text-white font-mono font-bold text-xl tabular-nums">{metrics.score}%</div>
             </div>
             <div className="text-center">
-              <div className="text-[9px] text-slate-500 uppercase font-bold tracking-wider mb-1">At Risk</div>
-              <div className={`font-mono font-bold text-xl tabular-nums ${controlsAtRisk === 0 ? 'text-emerald-400' : 'text-rose-400'}`}>{controlsAtRisk}</div>
+              <div className="text-[9px] text-slate-500 uppercase font-bold tracking-wider mb-1">Failing</div>
+              <div className={`font-mono font-bold text-xl tabular-nums ${failedCount === 0 ? 'text-emerald-400' : 'text-rose-400'}`}>{failedCount}</div>
             </div>
             <div className="text-center">
               <div className="text-[9px] text-slate-500 uppercase font-bold tracking-wider mb-1">Target</div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -397,7 +397,6 @@ const DashboardContent = memo(() => {
   }[globalStatus] || { label: 'Unknown', color: 'text-slate-400', bg: 'bg-slate-500/10', border: 'border-slate-500/20', dot: 'bg-slate-500', solid: 'bg-slate-500' };
 
   const lastRunDate = metadata?.validation_date ? new Date(metadata.validation_date) : null;
-  const failedCount = parseInt(metrics.failed);
 
   return (
     <div className="space-y-6 animate-in fade-in duration-500 slide-in-from-bottom-4">
@@ -431,10 +430,6 @@ const DashboardContent = memo(() => {
             <div className="text-center">
               <div className="text-[9px] text-slate-500 uppercase font-bold tracking-wider mb-1">Pass Rate</div>
               <div className="text-white font-mono font-bold text-xl tabular-nums">{metrics.score}%</div>
-            </div>
-            <div className="text-center">
-              <div className="text-[9px] text-slate-500 uppercase font-bold tracking-wider mb-1">Failing</div>
-              <div className={`font-mono font-bold text-xl tabular-nums ${failedCount === 0 ? 'text-emerald-400' : 'text-rose-400'}`}>{failedCount}</div>
             </div>
             <div className="text-center">
               <div className="text-[9px] text-slate-500 uppercase font-bold tracking-wider mb-1">Target</div>

--- a/src/components/findings/KSIGrid.jsx
+++ b/src/components/findings/KSIGrid.jsx
@@ -4,23 +4,9 @@ import { useModal } from '../../contexts/ModalContext';
 import { useAuth } from '../../hooks/useAuth';
 import { Sanitizer } from '../../utils/sanitizer';
 import {
-  Search, X, ChevronDown, ChevronRight, Clock,
+  Search, X, ChevronDown, ChevronRight,
   CheckCircle2, XCircle, AlertTriangle, Info, Terminal, Lock, Layers
 } from 'lucide-react';
-
-const getRelativeTime = (timestamp) => {
-  if (!timestamp) return null;
-  const date = new Date(timestamp);
-  const now = new Date();
-  const diffMs = now - date;
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMins / 60);
-  const diffDays = Math.floor(diffHours / 24);
-  if (diffDays > 0) return `${diffDays}d ago`;
-  if (diffHours > 0) return `${diffHours}h ago`;
-  if (diffMins > 0) return `${diffMins}m ago`;
-  return 'just now';
-};
 
 export const KSIGrid = () => {
   const { ksis, loading } = useData();
@@ -220,7 +206,6 @@ const KSICard = ({ ksi, openModal }) => {
 
   const IconMap = { 'CheckCircle2': CheckCircle2, 'XCircle': XCircle, 'AlertTriangle': AlertTriangle, 'Info': Info };
   const Icon = IconMap[meta.icon] || Info;
-  const relTime = getRelativeTime(ksi.timestamp);
 
   return (
     <div
@@ -256,15 +241,6 @@ const KSICard = ({ ksi, openModal }) => {
       <div className="pl-3 pt-3 border-t border-gray-700 flex items-center justify-between">
         <div className="flex items-center gap-3 text-xs text-gray-500 font-medium">
           <span>{ksi.commands_executed} checks</span>
-          {relTime && (
-            <>
-              <span className="text-gray-700">&middot;</span>
-              <span className="flex items-center gap-1">
-                <Clock size={10} />
-                {relTime}
-              </span>
-            </>
-          )}
         </div>
 
         <button

--- a/src/components/modals/WhyModal.jsx
+++ b/src/components/modals/WhyModal.jsx
@@ -10,7 +10,7 @@ import {
   AlertTriangle, CheckCircle, Info, FileText, Terminal, Shield,
   ChevronDown, ChevronRight, Database, Cpu, Lock, Layers,
   Target, GitBranch, Zap, Server, Key, Network,
-  Globe, Activity, Eye, Settings, Archive, Users, Search, Cloud, Clock
+  Globe, Activity, Eye, Settings, Archive, Users, Search, Cloud
 } from 'lucide-react';
 
 // Icon mapping for services
@@ -155,12 +155,6 @@ export const WhyModal = () => {
                 <span className="font-mono">{parsed.score}%</span>
                 <span className="text-gray-700">&middot;</span>
                 <span>{parsed.checksSummary.passedChecks}/{parsed.checksSummary.totalChecks} checks passed</span>
-                {parsed.timestamp && (
-                  <>
-                    <span className="text-gray-700">&middot;</span>
-                    <span className="flex items-center gap-1"><Clock size={10} />{new Date(parsed.timestamp).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}</span>
-                  </>
-                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Overhauls the trust center presentation layer to use the pipeline's `display_status` field and present compliance data clearly for auditors, agencies, and FedRAMP reviewers.

### Data integration
- **`display_status`** (`pass` | `meets_threshold` | `fail`) is now the source of truth for KSI status — replaces fragile score-threshold and assertion_reason text parsing
- **`global_status`** (`OPERATIONAL` / `DEGRADED` / `CIRCUIT_BROKEN`) surfaced as the dashboard headline
- Status labels: Operational, Meets Threshold, Fail (replaces Excellent/Good/Insufficient)

### Dashboard layout
- **Single unified header** — merged two redundant banners (ImpactBanner + stats cards) into one row: status, pass rate, target, timestamp, sync
- **KSI grid immediately visible** — no chart or wrapper chrome blocking the controls
- **Validation Velocity chart moved below** the grid (context, not blocking)
- Removed misleading "At Risk" / "Failing" counter — pass rate and target already tell the story

### KSI grid improvements
- **Failed controls sort to top** within category groups; categories with failures sort first
- **Filter tabs**: All, Operational, Failed, Meets Threshold (conditional on data)
- **Category headers simplified** — red/green icon with failed count, removed percentage progress bars
- Removed per-KSI timestamps (pipeline validates all KSIs in one pass — freshness is global)

### WhyModal redesign
- **Status-adaptive sections** — passing KSIs show 2-3 sections, failing show 4-5 with remediation prominent
- Merged status + requirement + category into single header block
- Removed duplicate panels (Checks Executed, Assessment Findings, Services Validated as separate section)
- Folded service summary into Validation Evidence as compact inline chips
- Pass/Fail Criteria and Recommended Action hidden for passing controls
- **Cut from 525 lines to 256**

### Infrastructure
- Extracted shared `THEME` and `BASE_PATH` to `src/config/theme.js` — eliminated 10 duplicate definitions across components
- `meets_threshold` uses blue (not emerald) to visually distinguish from green pass

## Test plan
- [ ] Verify dashboard loads with single header showing global_status
- [ ] Verify KSI grid shows failed controls first
- [ ] Verify filter tabs work (All, Operational, Failed, Meets Threshold)
- [ ] Verify WhyModal for passing KSI: compact, no unnecessary sections
- [ ] Verify WhyModal for failing KSI: remediation prominent, evidence expanded
- [ ] Verify Trust Center, VDR, Transparency Console pages unaffected
- [ ] Verify build passes with no errors

https://claude.ai/code/session_013iu1XzQr7jK3wWDqRgr3CJ