### PR TITLE
Redesign trust center presentation layer for display_status pipeline

### DIFF
--- a/src/components/findings/KSIGrid.jsx
+++ b/src/components/findings/KSIGrid.jsx
@@ -3,7 +3,7 @@ import { useData } from '../../hooks/useData';
 import { useModal } from '../../contexts/ModalContext';
 import { Sanitizer } from '../../utils/sanitizer';
 import {
-  Search, X, ChevronDown, ChevronRight,
+  Search, X, ChevronDown, ChevronRight, ArrowRight,
   CheckCircle2, XCircle, AlertTriangle, Info, Layers
 } from 'lucide-react';
 
@@ -208,7 +208,7 @@ const KSICard = ({ ksi, openModal }) => {
   return (
     <div
       onClick={() => openModal('why', ksi)}
-      className={`group bg-gray-800 rounded-lg border border-gray-700 p-5 hover:border-gray-600 transition-all cursor-pointer flex flex-col h-full relative overflow-hidden`}
+      className={`group bg-gray-800 rounded-lg border border-gray-700 p-5 hover:border-blue-500/40 hover:bg-gray-800/80 transition-all cursor-pointer flex flex-col h-full relative overflow-hidden`}
     >
       {/* Colored Accent Line (Left) */}
       <div className={`absolute left-0 top-0 bottom-0 w-1 ${colors.border}`}></div>
@@ -222,7 +222,7 @@ const KSICard = ({ ksi, openModal }) => {
         </span>
       </div>
 
-      <h4 className="pl-3 text-sm font-medium text-gray-200 mb-2 group-hover:text-blue-400 transition-colors leading-relaxed flex-1">
+      <h4 className="pl-3 text-sm font-medium text-gray-200 mb-2 group-hover:text-white transition-colors leading-relaxed flex-1">
         {ksi.description}
       </h4>
       {ksi.status === 'warning' && (
@@ -236,8 +236,12 @@ const KSICard = ({ ksi, openModal }) => {
         </p>
       )}
 
-      <div className="pl-3 pt-3 border-t border-gray-700 flex items-center text-xs text-gray-500 font-medium">
-        <span>{ksi.commands_executed} checks</span>
+      <div className="pl-3 pt-3 border-t border-gray-700 flex items-center justify-between">
+        <span className="text-xs text-gray-500 font-medium">{ksi.commands_executed} checks</span>
+        <span className="text-xs font-bold text-gray-500 group-hover:text-blue-400 flex items-center gap-1 transition-colors">
+          View evidence
+          <ArrowRight size={12} className="group-hover:translate-x-0.5 transition-transform" />
+        </span>
       </div>
     </div>
   );

--- a/src/components/findings/KSIGrid.jsx
+++ b/src/components/findings/KSIGrid.jsx
@@ -1,11 +1,10 @@
 import React, { useState, useMemo } from 'react';
 import { useData } from '../../hooks/useData';
 import { useModal } from '../../contexts/ModalContext';
-import { useAuth } from '../../hooks/useAuth';
 import { Sanitizer } from '../../utils/sanitizer';
 import {
   Search, X, ChevronDown, ChevronRight,
-  CheckCircle2, XCircle, AlertTriangle, Info, Terminal, Lock, Layers
+  CheckCircle2, XCircle, AlertTriangle, Info, Layers
 } from 'lucide-react';
 
 export const KSIGrid = () => {
@@ -192,7 +191,6 @@ const FilterTab = ({ label, count, active, onClick }) => (
 );
 
 const KSICard = ({ ksi, openModal }) => {
-  const { isAuthenticated } = useAuth();
   const meta = Sanitizer.mapStatus(ksi.status);
 
   // Color mapping — blue for meets_threshold to distinguish from green pass
@@ -238,25 +236,8 @@ const KSICard = ({ ksi, openModal }) => {
         </p>
       )}
 
-      <div className="pl-3 pt-3 border-t border-gray-700 flex items-center justify-between">
-        <div className="flex items-center gap-3 text-xs text-gray-500 font-medium">
-          <span>{ksi.commands_executed} checks</span>
-        </div>
-
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            if (!isAuthenticated) {
-              openModal('accessRequired', { featureName: 'CLI Logs', benefits: ['View raw CLI commands'] });
-            } else {
-              openModal('cli', ksi);
-            }
-          }}
-          className="text-xs font-bold text-gray-400 hover:text-white flex items-center gap-1 transition-colors"
-        >
-          {isAuthenticated ? <Terminal size={14} /> : <Lock size={12} />}
-          View CLI
-        </button>
+      <div className="pl-3 pt-3 border-t border-gray-700 flex items-center text-xs text-gray-500 font-medium">
+        <span>{ksi.commands_executed} checks</span>
       </div>
     </div>
   );

--- a/src/components/findings/KSIGrid.jsx
+++ b/src/components/findings/KSIGrid.jsx
@@ -239,7 +239,7 @@ const KSICard = ({ ksi, openModal }) => {
       <div className="pl-3 pt-3 border-t border-gray-700 flex items-center justify-between">
         <span className="text-xs text-gray-500 font-medium">{ksi.commands_executed} checks</span>
         <span className="text-xs font-bold text-gray-500 group-hover:text-blue-400 flex items-center gap-1 transition-colors">
-          View evidence
+          Details
           <ArrowRight size={12} className="group-hover:translate-x-0.5 transition-transform" />
         </span>
       </div>

--- a/src/components/modals/WhyModal.jsx
+++ b/src/components/modals/WhyModal.jsx
@@ -124,7 +124,7 @@ export const WhyModal = () => {
             <Shield size={28} className="text-gray-500 mx-auto mb-3" />
             <h4 className="font-semibold text-white text-lg mb-2">Federal Access Required</h4>
             <p className="text-sm text-gray-400 mb-5 max-w-sm mx-auto">
-              Technical findings and evidence are restricted to authorized personnel.
+              Technical findings and command logs are restricted to authorized personnel.
             </p>
             <button
               onClick={() => { closeModal('why'); openModal('registration'); }}
@@ -185,10 +185,10 @@ export const WhyModal = () => {
           </Section>
         )}
 
-        {/* Validation Checks — the actual evidence */}
+        {/* Validation Checks — which CLI commands ran and their pass/fail */}
         {parsed.checks.length > 0 && (
           <Section
-            title="Validation Evidence"
+            title="Validation Checks"
             icon={Terminal}
             defaultOpen={isFailing}
             badge={`${parsed.checksSummary.passedChecks}/${parsed.checksSummary.totalChecks}`}


### PR DESCRIPTION
## Summary

Overhauls the trust center presentation layer to use the pipeline's `display_status` field and present compliance data clearly for auditors, agencies, and FedRAMP reviewers.

### Data integration
- **`display_status`** (`pass` | `meets_threshold` | `fail`) is now the source of truth for KSI status — replaces fragile score-threshold and assertion_reason text parsing
- **`global_status`** (`OPERATIONAL` / `DEGRADED` / `CIRCUIT_BROKEN`) surfaced as the dashboard headline
- Status labels: Operational, Meets Threshold, Fail (replaces Excellent/Good/Insufficient)

### Dashboard layout
- **Single unified header** — merged two redundant banners into one row: status, pass rate, target, timestamp, sync
- **KSI grid immediately visible** — no chart or wrapper chrome blocking the controls
- **Validation Velocity chart moved below** the grid (context, not blocking)
- Removed misleading "At Risk" / "Failing" counter — pass rate and target already tell the story

### KSI grid improvements
- **Failed controls sort to top** within category groups; categories with failures sort first
- **Filter tabs**: All, Operational, Failed, Meets Threshold (conditional on data)
- **Category headers simplified** — red/green icon with failed count, removed percentage progress bars
- **Removed per-KSI timestamps** — pipeline validates all KSIs in one pass, freshness is a global property already shown in the header
- **Removed redundant View CLI button** — WhyModal already shows evidence, single entry point via card click

### WhyModal redesign
- **Status-adaptive sections** — passing KSIs show 2-3 sections, failing show 4-5 with remediation prominent
- Merged status + requirement + category into single header block
- Removed duplicate panels (Checks Executed, Assessment Findings, Services Validated as separate section)
- Folded service summary into Validation Evidence as compact inline chips
- Pass/Fail Criteria and Recommended Action hidden for passing controls
- **Cut from 525 lines to 256**

### Infrastructure
- Extracted shared `THEME` and `BASE_PATH` to `src/config/theme.js` — eliminated 10 duplicate definitions across components
- `meets_threshold` uses blue (not emerald) to visually distinguish from green pass

## Test plan
- [ ] Verify dashboard loads with single header showing global_status
- [ ] Verify KSI grid shows failed controls first
- [ ] Verify filter tabs work (All, Operational, Failed, Meets Threshold)
- [ ] Verify WhyModal for passing KSI: compact, no unnecessary sections
- [ ] Verify WhyModal for failing KSI: remediation prominent, evidence expanded
- [ ] Verify Trust Center, VDR, Transparency Console pages unaffected
- [ ] Verify build passes with no errors

https://claude.ai/code/session_013iu1XzQr7jK3wWDqRgr3CJ