### PR TITLE
Redesign trust center presentation layer for display_status pipeline

### DIFF
--- a/src/components/findings/KSIGrid.jsx
+++ b/src/components/findings/KSIGrid.jsx
@@ -225,16 +225,6 @@ const KSICard = ({ ksi, openModal }) => {
       <h4 className="pl-3 text-sm font-medium text-gray-200 mb-2 group-hover:text-white transition-colors leading-relaxed flex-1">
         {ksi.description}
       </h4>
-      {ksi.status === 'warning' && (
-        <p className="pl-3 text-[10px] text-amber-400/70 mb-2 leading-snug">
-          Passes validation but has conditions requiring ongoing monitoring
-        </p>
-      )}
-      {ksi.status === 'failed' && (
-        <p className="pl-3 text-[10px] text-red-400/70 mb-2 leading-snug">
-          Failed validation — corrective action required
-        </p>
-      )}
 
       <div className="pl-3 pt-3 border-t border-gray-700 flex items-center justify-between">
         <span className="text-xs text-gray-500 font-medium">{ksi.commands_executed} checks</span>

--- a/src/components/findings/KSIGrid.jsx
+++ b/src/components/findings/KSIGrid.jsx
@@ -227,7 +227,7 @@ const KSICard = ({ ksi, openModal }) => {
       </h4>
 
       <div className="pl-3 pt-3 border-t border-gray-700 flex items-center justify-between">
-        <span className="text-xs text-gray-500 font-medium">{ksi.commands_executed} checks</span>
+        <span className="text-xs text-gray-500 font-medium">{ksi.commands_executed} CLI checks</span>
         <span className="text-xs font-bold text-gray-500 group-hover:text-blue-400 flex items-center gap-1 transition-colors">
           Details
           <ArrowRight size={12} className="group-hover:translate-x-0.5 transition-transform" />

--- a/src/components/modals/WhyModal.jsx
+++ b/src/components/modals/WhyModal.jsx
@@ -52,12 +52,11 @@ const Section = ({ title, icon: Icon, defaultOpen = false, children, badge, badg
   );
 };
 
-// Single CLI check row
+// Single CLI check row — check name + the CLI command that was run, always visible
 const CheckRow = ({ check }) => {
-  const [showCmd, setShowCmd] = useState(false);
   return (
     <div className={`p-3 rounded-lg border ${check.passed ? 'border-green-500/20 bg-green-500/5' : 'border-red-500/20 bg-red-500/5'}`}>
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex items-center justify-between gap-3 mb-2">
         <div className="flex items-center gap-2.5 min-w-0 flex-1">
           <div className={`p-1 rounded ${check.passed ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'}`}>
             <ServiceIcon name={check.service} size={12} />
@@ -65,22 +64,15 @@ const CheckRow = ({ check }) => {
           <span className="text-sm text-white truncate">{check.name}</span>
           {check.executionTime && <span className="text-[10px] text-gray-500 flex-shrink-0">{check.executionTime}</span>}
         </div>
-        <div className="flex items-center gap-2 flex-shrink-0">
-          <button onClick={() => setShowCmd(!showCmd)} className="text-[10px] text-gray-500 hover:text-gray-300">
-            <Terminal size={12} />
-          </button>
-          <span className={`px-2 py-0.5 rounded text-[10px] font-bold ${check.passed ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'}`}>
-            {check.passed ? 'PASS' : 'FAIL'}
-          </span>
-        </div>
+        <span className={`px-2 py-0.5 rounded text-[10px] font-bold flex-shrink-0 ${check.passed ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'}`}>
+          {check.passed ? 'PASS' : 'FAIL'}
+        </span>
       </div>
+      <pre className="text-xs bg-black/40 p-2 rounded border border-gray-800 text-green-300 font-mono overflow-x-auto">
+        <span className="text-blue-400 select-none">$ </span>{check.command}
+      </pre>
       {check.errorMessage && !check.passed && (
         <p className="text-xs text-red-300 mt-2 bg-red-500/10 p-2 rounded">{check.errorMessage}</p>
-      )}
-      {showCmd && (
-        <pre className="mt-2 text-xs bg-black/40 p-2 rounded border border-gray-800 text-green-300 font-mono overflow-x-auto">
-          <span className="text-blue-400 select-none">$ </span>{check.command}
-        </pre>
       )}
     </div>
   );
@@ -185,10 +177,10 @@ export const WhyModal = () => {
           </Section>
         )}
 
-        {/* Validation Checks — which CLI commands ran and their pass/fail */}
+        {/* CLI Validation Commands — each check is an AWS CLI command with its result */}
         {parsed.checks.length > 0 && (
           <Section
-            title="Validation Checks"
+            title="CLI Validation Commands"
             icon={Terminal}
             defaultOpen={isFailing}
             badge={`${parsed.checksSummary.passedChecks}/${parsed.checksSummary.totalChecks}`}


### PR DESCRIPTION
## Summary

Overhauls the trust center presentation layer to use the pipeline's `display_status` field and present compliance data clearly for auditors, agencies, and FedRAMP reviewers.

### Data integration
- **`display_status`** (`pass` | `meets_threshold` | `fail`) is now the source of truth for KSI status — replaces fragile score-threshold and assertion_reason text parsing
- **`global_status`** (`OPERATIONAL` / `DEGRADED` / `CIRCUIT_BROKEN`) surfaced as the dashboard headline
- Status labels: Operational, Meets Threshold, Fail (replaces Excellent/Good/Insufficient)

### Dashboard layout
- **Single unified header** — merged two redundant banners into one row: status, pass rate, target, timestamp, sync
- **KSI grid immediately visible** — no chart or wrapper chrome blocking the controls
- **Validation Velocity chart moved below** the grid (context, not blocking)
- Removed misleading "At Risk" / "Failing" counter — pass rate and target already tell the story

### KSI grid improvements
- **Failed controls sort to top** within category groups; categories with failures sort first
- **Filter tabs**: All, Operational, Failed, Meets Threshold (conditional on data)
- **Category headers simplified** — red/green icon with failed count, removed percentage progress bars
- **Removed per-KSI timestamps** — pipeline validates all KSIs in one pass, freshness is a global property
- **Removed redundant View CLI button** — WhyModal already shows the CLI checks
- **Added "Details →" affordance** to card footer for clear click indication
- **Removed redundant status sub-text** paragraphs that duplicated the status badge

### WhyModal redesign
- **Status-adaptive sections** — passing KSIs show 2-3 sections, failing show 4-5 with remediation prominent
- Merged status + requirement + category into single header block
- Removed duplicate panels (Checks Executed, Assessment Findings, Services Validated as separate section)
- Folded service summary into CLI Validation Commands as compact inline chips
- Pass/Fail Criteria and Recommended Action hidden for passing controls
- **Consolidated "Checks" and "CLI" as one concept** — section renamed to "CLI Validation Commands", each row shows the AWS CLI command inline (no toggle)
- **Cut from 525 lines to ~245**

### Infrastructure
- Extracted shared `THEME` and `BASE_PATH` to `src/config/theme.js` — eliminated 10 duplicate definitions across components
- `meets_threshold` uses blue (not emerald) to visually distinguish from green pass
- Renamed misleading "evidence" terminology to "command logs" / "CLI checks" (the raw forensic evidence lives in the private repo)

## Test plan
- [ ] Verify dashboard loads with single header showing global_status
- [ ] Verify KSI grid shows failed controls first
- [ ] Verify filter tabs work (All, Operational, Failed, Meets Threshold)
- [ ] Verify card shows "N CLI checks · Details →" affordance
- [ ] Verify WhyModal for passing KSI: compact, no unnecessary sections
- [ ] Verify WhyModal for failing KSI: remediation prominent, CLI commands expanded
- [ ] Verify CLI commands are visible inline in each check row
- [ ] Verify Trust Center, VDR, Transparency Console pages unaffected
- [ ] Verify build passes with no errors

https://claude.ai/code/session_013iu1XzQr7jK3wWDqRgr3CJ