### PR TITLE
Add download functionality to Trust Center footer actions

### DIFF
--- a/src/components/findings/KSIGrid.jsx
+++ b/src/components/findings/KSIGrid.jsx
@@ -226,10 +226,9 @@ const KSICard = ({ ksi, openModal }) => {
         {ksi.description}
       </h4>
 
-      <div className="pl-3 pt-3 border-t border-gray-700 flex items-center justify-between">
-        <span className="text-xs text-gray-500 font-medium">{ksi.commands_executed} CLI checks</span>
+      <div className="pl-3 pt-3 border-t border-gray-700 flex items-center justify-end">
         <span className="text-xs font-bold text-gray-500 group-hover:text-blue-400 flex items-center gap-1 transition-colors">
-          Details
+          View {ksi.commands_executed} CLI checks
           <ArrowRight size={12} className="group-hover:translate-x-0.5 transition-transform" />
         </span>
       </div>

--- a/src/components/trust/TrustCenterView.jsx
+++ b/src/components/trust/TrustCenterView.jsx
@@ -539,7 +539,20 @@ export const TrustCenterView = () => {
         return true;
     };
 
-    const openApiDocs = () => window.open('https://meridian-knowledge-solutions.github.io/fedramp-20x-public/documentation/api/', '_blank');
+    const API_DOCS_URL = 'https://meridian-knowledge-solutions.github.io/fedramp-20x-public/documentation/api/';
+
+    const openApiDocs = () => window.open(API_DOCS_URL, '_blank');
+
+    const triggerDownload = (blob, filename) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    };
 
     const viewSecureConfig = async () => {
         if (!handleAction('View Secure Configuration')) return;
@@ -549,6 +562,30 @@ export const TrustCenterView = () => {
             const text = await res.text();
             openModal('markdown', { title: 'Secure Configuration', markdown: text });
         } catch (e) { alert('Load failed.'); }
+    };
+
+    const downloadSecureConfig = async () => {
+        if (!handleAction('Download Secure Configuration')) return;
+        try {
+            const url = `${API_CONFIG.BASE_URL}${API_CONFIG.ENDPOINTS.CONFIG_PUBLIC}`;
+            const res = await fetch(url);
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const text = await res.text();
+            triggerDownload(new Blob([text], { type: 'text/markdown' }), 'secure-configuration.md');
+        } catch (e) { alert(`Download failed: ${e.message}`); }
+    };
+
+    const downloadApiDocs = async () => {
+        if (!handleAction('Download API Documentation')) return;
+        try {
+            const res = await fetch(API_DOCS_URL);
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const text = await res.text();
+            triggerDownload(new Blob([text], { type: 'text/html' }), 'fedramp-20x-api-docs.html');
+        } catch (e) {
+            // Fallback: open in new tab if direct download is blocked (e.g., CORS)
+            window.open(API_DOCS_URL, '_blank');
+        }
     };
 
     const handleDownloadPackage = async () => {
@@ -759,8 +796,8 @@ export const TrustCenterView = () => {
 
                 {/* --- FOOTER ACTIONS --- */}
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4 pb-8 mt-8">
-                    <FooterAction title="API Docs" onClick={openApiDocs} />
-                    <FooterAction title="Secure Config" onClick={viewSecureConfig} />
+                    <FooterAction title="API Docs" onClick={openApiDocs} onDownload={downloadApiDocs} downloadLabel="Download API documentation" />
+                    <FooterAction title="Secure Config" onClick={viewSecureConfig} onDownload={downloadSecureConfig} downloadLabel="Download secure configuration" />
                     <FooterAction title="Support" onClick={() => window.location.href = 'mailto:support@meridianks.com'} />
                 </div>
             </div>
@@ -961,8 +998,30 @@ const ArtifactBadge = ({ label }) => (
 
 // ClassificationBadge removed — no longer used
 
-const FooterAction = ({ title, onClick }) => (
-    <button onClick={onClick} className={`${THEME.panel} border ${THEME.border} hover:bg-[#18181b] p-4 rounded-xl flex items-center justify-center gap-2 text-sm font-bold text-slate-300 hover:text-white transition-all group`}>
-        {title}
-    </button>
-);
+const FooterAction = ({ title, onClick, onDownload, downloadLabel }) => {
+    if (!onDownload) {
+        return (
+            <button onClick={onClick} className={`${THEME.panel} border ${THEME.border} hover:bg-[#18181b] p-4 rounded-xl flex items-center justify-center gap-2 text-sm font-bold text-slate-300 hover:text-white transition-all group`}>
+                {title}
+            </button>
+        );
+    }
+    return (
+        <div className={`${THEME.panel} border ${THEME.border} rounded-xl flex items-stretch overflow-hidden transition-all group`}>
+            <button
+                onClick={onClick}
+                className="flex-1 p-4 flex items-center justify-center gap-2 text-sm font-bold text-slate-300 hover:text-white hover:bg-[#18181b] transition-all"
+            >
+                {title}
+            </button>
+            <button
+                onClick={onDownload}
+                aria-label={downloadLabel || `Download ${title}`}
+                title={downloadLabel || `Download ${title}`}
+                className="px-4 flex items-center justify-center text-slate-400 hover:text-white hover:bg-[#18181b] border-l border-white/5 transition-all"
+            >
+                <Download size={16} />
+            </button>
+        </div>
+    );
+};


### PR DESCRIPTION
## Summary
Enhanced the Trust Center View with download capabilities for API documentation and secure configuration files, while improving the KSI Grid card layout for better UX.

## Key Changes

### Trust Center View (`TrustCenterView.jsx`)
- **Extracted API docs URL** to a constant (`API_DOCS_URL`) for better maintainability
- **Added `triggerDownload` utility function** to handle blob downloads with proper cleanup (creates temporary anchor element, triggers download, revokes object URL)
- **Implemented `downloadSecureConfig` function** to fetch and download secure configuration as markdown file
- **Implemented `downloadApiDocs` function** to fetch and download API documentation as HTML, with fallback to opening in new tab if CORS blocks direct download
- **Enhanced `FooterAction` component** to support optional download button:
  - Maintains backward compatibility for actions without download (single button)
  - Splits into two-button layout when download is enabled (main action + download icon button)
  - Added proper accessibility labels and tooltips for download buttons
- **Updated footer action calls** to pass download handlers and labels for "API Docs" and "Secure Config" actions

### KSI Grid (`KSIGrid.jsx`)
- **Improved KSICard footer layout** by:
  - Removing the separate CLI checks count display
  - Consolidating information into the "View" action text: "View {count} CLI checks"
  - Changing layout from `justify-between` to `justify-end` for cleaner alignment

## Implementation Details
- Download functions include error handling with user-friendly alerts
- API docs download includes CORS fallback to prevent broken UX
- All downloads use appropriate MIME types (markdown for config, HTML for docs)
- Download button uses Download icon from existing icon library
- Changes maintain existing styling and theme consistency

https://claude.ai/code/session_01T2pK9eaXfJKa7uMuf1C3Vu