### PR TITLE
Add FedRAMP 20x Remediation Register & Backlog Integration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import {
   LayoutDashboard, ShieldAlert, User, LogOut,
   Menu, Activity, Calendar, Clock,
   FileText, RefreshCw, BarChart3, Eye, X, Shield, Layers,
-  BookOpen, Code2, FileBarChart, Database
+  BookOpen, Code2, FileBarChart, Database, ListTodo
 } from 'lucide-react';
 
 import {
@@ -28,6 +28,8 @@ import { UnifiedMasDashboard } from './components/trust/UnifiedMasDashboard';
 import { PoliciesTab } from './components/trust/PoliciesTab';
 import { SchemaTab } from './components/trust/SchemaTab';
 import { ReportsTab } from './components/trust/ReportsTab';
+import { RemediationRegister } from './components/trust/RemediationRegister';
+import { RemediationHeatmap } from './components/trust/RemediationHeatmap';
 import { TrustCenterDataProvider } from './hooks/useTrustCenterData';
 
 import { THEME, BASE_PATH } from './config/theme';
@@ -377,7 +379,7 @@ const ComplianceChart = memo(() => {
   );
 });
 
-const DashboardContent = memo(() => {
+const DashboardContent = memo(({ onOpenRegister }) => {
   const { metrics, ksis, metadata, reload } = useData();
   const [isRefreshing, setIsRefreshing] = useState(false);
 
@@ -463,6 +465,11 @@ const DashboardContent = memo(() => {
         </div>
       </div>
 
+      {/* Remediation Backlog severity strip — only renders if backlog is published */}
+      <RemediationHeatmap
+        onSelectSeverity={(sev) => onOpenRegister?.(sev ? { severity: sev } : {})}
+      />
+
       {/* KSI Grid — directly after header, no wrapper chrome */}
       <KSIGrid />
 
@@ -478,11 +485,19 @@ const AppShell = () => {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [activeView, setActiveView] = useState('dashboard');
+  const [registerFilters, setRegisterFilters] = useState({});
   const [settingsOpen, setSettingsOpen] = useState(false);
   const scrollY = useScrollPosition();
 
   const { user, isAuthenticated, logout } = useAuth();
   const { openModal } = useModal();
+
+  // Navigate to the Remediation Register, optionally pre-filtered (e.g. heatmap click).
+  const goToRegister = useCallback((filters = {}) => {
+    setRegisterFilters(filters);
+    setActiveView('register');
+    setMobileMenuOpen(false);
+  }, []);
 
   return (
     <div className={`flex h-screen ${THEME.bg} text-slate-300 font-sans overflow-hidden selection:bg-blue-500/30`}>
@@ -563,6 +578,12 @@ const AppShell = () => {
               label="Failure History"
               isActive={activeView === 'failures'}
               onClick={() => { setActiveView('failures'); setMobileMenuOpen(false); }}
+            />
+            <SidebarItem
+              icon={ListTodo}
+              label="Remediation Register"
+              isActive={activeView === 'register'}
+              onClick={() => goToRegister({})}
             />
             <SidebarItem
               icon={Layers}
@@ -679,6 +700,12 @@ const AppShell = () => {
               onClick={() => setActiveView('failures')}
             />
             <SidebarItem
+              icon={ListTodo}
+              label="Remediation Register"
+              isActive={activeView === 'register'}
+              onClick={() => goToRegister({})}
+            />
+            <SidebarItem
               icon={Layers}
               label="Assessment Scope"
               isActive={activeView === 'mas'}
@@ -754,6 +781,7 @@ const AppShell = () => {
                 {activeView === 'transparency' && 'Platform / Transparency Console'}
                 {activeView === 'metrics' && 'Platform / Pipeline Metrics'}
                 {activeView === 'failures' && 'Platform / Failure History'}
+                {activeView === 'register' && 'Platform / Remediation Register'}
                 {activeView === 'mas' && 'Platform / Assessment Scope'}
                 {activeView === 'policies' && 'Organization / Policies'}
                 {activeView === 'schema' && 'Organization / Schema'}
@@ -781,8 +809,9 @@ const AppShell = () => {
           <div className="absolute bottom-0 right-1/4 w-96 h-96 bg-indigo-600/5 rounded-full blur-[120px] pointer-events-none mix-blend-screen animate-pulse-slow" style={{ animationDelay: '1s' }} />
 
           <div className="p-4 sm:p-6 lg:p-8 max-w-[1600px] mx-auto relative z-10">
-            {activeView === 'dashboard' ? <DashboardContent /> :
+            {activeView === 'dashboard' ? <DashboardContent onOpenRegister={goToRegister} /> :
               activeView === 'trust' ? <TrustCenterView /> :
+              activeView === 'register' ? <RemediationRegister initialFilters={registerFilters} /> :
               !isAuthenticated ? (
                 <div className="flex items-center justify-center min-h-[60vh]">
                   <div className="bg-gradient-to-br from-gray-900 to-gray-800 p-10 rounded-2xl border border-gray-700 text-center max-w-md">

--- a/src/components/findings/KSIGrid.jsx
+++ b/src/components/findings/KSIGrid.jsx
@@ -8,7 +8,7 @@ import {
 } from 'lucide-react';
 
 export const KSIGrid = () => {
-  const { ksis, loading } = useData();
+  const { ksis, loading, backlogByKsi } = useData();
   const { openModal } = useModal();
 
   const [searchTerm, setSearchTerm] = useState('');
@@ -115,7 +115,7 @@ export const KSIGrid = () => {
       {/* Category Sections */}
       <div className="space-y-8">
         {Object.entries(groupedKsis).map(([category, items]) => (
-          <CategorySection key={category} category={category} items={items} openModal={openModal} />
+          <CategorySection key={category} category={category} items={items} openModal={openModal} backlogByKsi={backlogByKsi} />
         ))}
 
         {filteredKsis.length === 0 && (
@@ -130,7 +130,7 @@ export const KSIGrid = () => {
 };
 
 // Collapsible Category Section
-const CategorySection = ({ category, items, openModal }) => {
+const CategorySection = ({ category, items, openModal, backlogByKsi }) => {
   const [isExpanded, setIsExpanded] = useState(true);
 
   const failed = items.filter(i => i.assertion === false || i.assertion === "false").length;
@@ -166,7 +166,7 @@ const CategorySection = ({ category, items, openModal }) => {
         <div className="p-6 bg-[#0B0C10] animate-in slide-in-from-top-2 duration-200">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {items.map(ksi => (
-              <KSICard key={ksi.id} ksi={ksi} openModal={openModal} />
+              <KSICard key={ksi.id} ksi={ksi} openModal={openModal} backlogStats={backlogByKsi?.[ksi.id]} />
             ))}
           </div>
         </div>
@@ -217,7 +217,7 @@ const ModeChip = ({ ksi }) => {
   );
 };
 
-const KSICard = ({ ksi, openModal }) => {
+const KSICard = ({ ksi, openModal, backlogStats }) => {
   const meta = Sanitizer.mapStatus(ksi.status);
 
   // Color mapping — blue for meets_threshold to distinguish from green pass
@@ -251,6 +251,11 @@ const KSICard = ({ ksi, openModal }) => {
             {ksi.id}
           </span>
           <ModeChip ksi={ksi} />
+          {backlogStats?.hasRiskAccepted && (
+            <span className="text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded border border-purple-500/30 bg-purple-500/10 text-purple-300">
+              Risk-accepted
+            </span>
+          )}
         </div>
         <span className={`text-[10px] px-2 py-1 rounded-full font-bold uppercase tracking-wider flex items-center gap-1.5 whitespace-nowrap ${colors.bg} ${colors.text}`}>
           <Icon size={12} /> {meta.label}

--- a/src/components/findings/KSIGrid.jsx
+++ b/src/components/findings/KSIGrid.jsx
@@ -190,6 +190,33 @@ const FilterTab = ({ label, count, active, onClick }) => (
   </button>
 );
 
+// FedRAMP 20x outcome-framework chip: distinguishes Capability-mode KSIs
+// (system presence + capability_status) from Output-mode KSIs (rate vs target).
+const ModeChip = ({ ksi }) => {
+  if (!ksi?.mode) return null;
+
+  if (ksi.mode === 'output') {
+    return (
+      <span className="text-[9px] font-mono uppercase tracking-wider px-1.5 py-0.5 rounded border bg-slate-900 text-slate-300 border-gray-700">
+        Output
+      </span>
+    );
+  }
+
+  const cap = ksi.capability_status;
+  const capColor =
+    cap === 'operational' ? 'text-emerald-400'
+    : cap === 'degraded' ? 'text-amber-400'
+    : cap === 'missing' ? 'text-red-400'
+    : 'text-slate-500';
+
+  return (
+    <span className="text-[9px] font-mono uppercase tracking-wider px-1.5 py-0.5 rounded border bg-slate-900 text-slate-300 border-gray-700">
+      Capability{cap && <> · <span className={capColor}>{cap}</span></>}
+    </span>
+  );
+};
+
 const KSICard = ({ ksi, openModal }) => {
   const meta = Sanitizer.mapStatus(ksi.status);
 
@@ -205,6 +232,11 @@ const KSICard = ({ ksi, openModal }) => {
   const IconMap = { 'CheckCircle2': CheckCircle2, 'XCircle': XCircle, 'AlertTriangle': AlertTriangle, 'Info': Info };
   const Icon = IconMap[meta.icon] || Info;
 
+  // Output-mode rate display: target is 95% per FedRAMP 20x outcome framework.
+  const isOutputMode = ksi.mode === 'output';
+  const outputTarget = 95;
+  const score = typeof ksi.score === 'number' ? ksi.score : (typeof ksi.score === 'string' ? parseFloat(ksi.score) : null);
+
   return (
     <div
       onClick={() => openModal('why', ksi)}
@@ -213,14 +245,26 @@ const KSICard = ({ ksi, openModal }) => {
       {/* Colored Accent Line (Left) */}
       <div className={`absolute left-0 top-0 bottom-0 w-1 ${colors.border}`}></div>
 
-      <div className="flex justify-between items-start mb-3 pl-3">
-        <span className="font-mono text-[10px] font-bold text-gray-500 bg-gray-900 px-2 py-1 rounded border border-gray-700">
-          {ksi.id}
-        </span>
-        <span className={`text-[10px] px-2 py-1 rounded-full font-bold uppercase tracking-wider flex items-center gap-1.5 ${colors.bg} ${colors.text}`}>
+      <div className="flex justify-between items-start mb-3 pl-3 gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-mono text-[10px] font-bold text-gray-500 bg-gray-900 px-2 py-1 rounded border border-gray-700">
+            {ksi.id}
+          </span>
+          <ModeChip ksi={ksi} />
+        </div>
+        <span className={`text-[10px] px-2 py-1 rounded-full font-bold uppercase tracking-wider flex items-center gap-1.5 whitespace-nowrap ${colors.bg} ${colors.text}`}>
           <Icon size={12} /> {meta.label}
         </span>
       </div>
+
+      {isOutputMode && score != null && (
+        <div className="pl-3 mb-2 text-[11px] font-mono">
+          <span className={score >= outputTarget ? 'text-emerald-400' : score === 0 ? 'text-red-400' : 'text-amber-400'}>
+            {score}%
+          </span>
+          <span className="text-gray-500"> (target {outputTarget}%)</span>
+        </div>
+      )}
 
       <h4 className="pl-3 text-sm font-medium text-gray-200 mb-2 group-hover:text-white transition-colors leading-relaxed flex-1">
         {ksi.description}

--- a/src/components/modals/WhyModal.jsx
+++ b/src/components/modals/WhyModal.jsx
@@ -12,10 +12,9 @@ import {
   ChevronDown, ChevronRight, Database, Cpu, Lock, Layers,
   Target, GitBranch, Zap, Server, Key, Network,
   Globe, Activity, Eye, Settings, Archive, Users, Search, Cloud,
-  AlertOctagon, AlertCircle, ExternalLink, Hash
+  AlertOctagon, AlertCircle, Hash
 } from 'lucide-react';
 
-const ISSUE_URL = 'https://github.com/Meridian-Knowledge-Solutions/fedramp-20x-submission-final/issues/238';
 const STALE_DAYS = 30;
 
 const SEVERITY_ICONS = {
@@ -276,17 +275,6 @@ export const WhyModal = () => {
                   Showing 25 of {backlogStats.items.length} items — see Remediation Register for the full list.
                 </p>
               )}
-              <div className="pt-2 border-t border-gray-700/50">
-                <a
-                  href={ISSUE_URL}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-1.5 text-[11px] font-bold text-blue-400 hover:text-blue-300"
-                >
-                  <ExternalLink size={11} />
-                  Owner, plan, and risk-acceptance details — see GitHub issue #238
-                </a>
-              </div>
             </div>
           </Section>
         )}

--- a/src/components/modals/WhyModal.jsx
+++ b/src/components/modals/WhyModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { useModal } from '../../contexts/ModalContext';
 import { useAuth } from '../../hooks/useAuth';
+import { useData } from '../../hooks/useData';
 import { BaseModal } from './BaseModal';
 import {
   parseKsiValidation,
@@ -10,8 +11,72 @@ import {
   AlertTriangle, CheckCircle, Info, FileText, Terminal, Shield,
   ChevronDown, ChevronRight, Database, Cpu, Lock, Layers,
   Target, GitBranch, Zap, Server, Key, Network,
-  Globe, Activity, Eye, Settings, Archive, Users, Search, Cloud
+  Globe, Activity, Eye, Settings, Archive, Users, Search, Cloud,
+  AlertOctagon, AlertCircle, ExternalLink, Hash
 } from 'lucide-react';
+
+const ISSUE_URL = 'https://github.com/Meridian-Knowledge-Solutions/fedramp-20x-submission-final/issues/238';
+const STALE_DAYS = 30;
+
+const SEVERITY_ICONS = {
+  CRITICAL: { Icon: AlertOctagon, text: 'text-red-400', dot: 'bg-red-500', bg: 'bg-red-500/10', border: 'border-red-500/30' },
+  HIGH: { Icon: AlertTriangle, text: 'text-orange-400', dot: 'bg-orange-500', bg: 'bg-orange-500/10', border: 'border-orange-500/30' },
+  MEDIUM: { Icon: AlertCircle, text: 'text-yellow-400', dot: 'bg-yellow-500', bg: 'bg-yellow-500/10', border: 'border-yellow-500/30' },
+  LOW: { Icon: Info, text: 'text-blue-400', dot: 'bg-blue-500', bg: 'bg-blue-500/10', border: 'border-blue-500/30' },
+};
+
+const STATE_LABELS = {
+  OPEN: { label: 'OPEN', text: 'text-slate-300', bg: 'bg-slate-500/10', border: 'border-slate-500/30' },
+  IN_PROGRESS: { label: 'IN PROGRESS', text: 'text-blue-300', bg: 'bg-blue-500/10', border: 'border-blue-500/30' },
+  RISK_ACCEPTED: { label: 'RISK ACCEPTED', text: 'text-purple-300', bg: 'bg-purple-500/10', border: 'border-purple-500/30' },
+  CLOSED: { label: 'CLOSED', text: 'text-emerald-300', bg: 'bg-emerald-500/10', border: 'border-emerald-500/30' },
+};
+
+const daysSince = (iso) => {
+  if (!iso) return null;
+  const ms = Date.now() - new Date(iso).getTime();
+  if (Number.isNaN(ms)) return null;
+  return Math.floor(ms / 86400000);
+};
+
+const BacklogItem = ({ item }) => {
+  const sev = SEVERITY_ICONS[item.severity] || SEVERITY_ICONS.LOW;
+  const state = STATE_LABELS[item.tracking?.state || 'OPEN'] || STATE_LABELS.OPEN;
+  const SevIcon = sev.Icon;
+  const age = daysSince(item.first_seen);
+  const isStale = (item.tracking?.state || 'OPEN') === 'OPEN' && age != null && age >= STALE_DAYS;
+
+  return (
+    <div className={`p-3 rounded-lg border ${sev.border} ${sev.bg}`}>
+      <div className="flex items-start gap-3">
+        <SevIcon size={14} className={`${sev.text} mt-0.5 flex-shrink-0`} />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap mb-1.5">
+            <span className={`text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded border ${sev.border} ${sev.text}`}>
+              {item.severity}
+            </span>
+            <span className={`text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded border ${state.border} ${state.bg} ${state.text}`}>
+              {state.label}
+            </span>
+            <span className="text-[10px] font-mono text-slate-500">
+              <Hash size={9} className="inline mr-1" />{item.resource}
+            </span>
+            {age != null && (
+              <span className="text-[10px] text-slate-500 font-mono">{age}d old</span>
+            )}
+            {isStale && (
+              <span className="text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded border border-amber-500/30 bg-amber-500/10 text-amber-300">
+                Stale
+              </span>
+            )}
+            <span className="text-[10px] font-mono text-slate-600 ml-auto">{item.id}</span>
+          </div>
+          <p className="text-[12px] text-slate-300 leading-relaxed font-mono break-words">{item.reason || '—'}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
 
 // Icon mapping for services
 const ServiceIcon = ({ name, size = 14 }) => {
@@ -81,10 +146,12 @@ const CheckRow = ({ check }) => {
 export const WhyModal = () => {
   const { modals, closeModal, openModal } = useModal();
   const { isAuthenticated } = useAuth();
+  const { backlogByKsi } = useData();
   const { isOpen, data } = modals.why;
 
   const parsed = useMemo(() => data ? parseKsiValidation(data) : null, [data]);
   const criteria = useMemo(() => parsed ? generateCriteriaText(parsed) : null, [parsed]);
+  const backlogStats = parsed ? backlogByKsi?.[parsed.id] : null;
 
   if (!data || !parsed) return null;
 
@@ -174,6 +241,53 @@ export const WhyModal = () => {
                 <span className="font-bold text-gray-400">Justification:</span> {data.justification}
               </p>
             )}
+          </Section>
+        )}
+
+        {/* Remediation Backlog — items linked to this KSI from remediation_backlog.json */}
+        {backlogStats && backlogStats.items.length > 0 && (
+          <Section
+            title="Remediation Backlog"
+            icon={Layers}
+            defaultOpen={isFailing}
+            badge={`${backlogStats.items.length}`}
+            badgeColor={backlogStats.severityCounts.CRITICAL > 0 ? 'red' : backlogStats.severityCounts.HIGH > 0 ? 'yellow' : 'blue'}
+          >
+            <div className="space-y-3">
+              {/* Quick severity breakdown */}
+              <div className="flex flex-wrap gap-2 pb-3 border-b border-gray-700/50">
+                {['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'].map(sev => {
+                  const count = backlogStats.severityCounts[sev];
+                  if (!count) return null;
+                  const cfg = SEVERITY_ICONS[sev];
+                  return (
+                    <span key={sev} className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider border ${cfg.border} ${cfg.bg} ${cfg.text}`}>
+                      <span className={`w-1.5 h-1.5 rounded-full ${cfg.dot}`} />
+                      {count} {sev}
+                    </span>
+                  );
+                })}
+              </div>
+              {backlogStats.items.slice(0, 25).map(item => (
+                <BacklogItem key={item.id} item={item} />
+              ))}
+              {backlogStats.items.length > 25 && (
+                <p className="text-[11px] text-slate-500 text-center pt-2">
+                  Showing 25 of {backlogStats.items.length} items — see Remediation Register for the full list.
+                </p>
+              )}
+              <div className="pt-2 border-t border-gray-700/50">
+                <a
+                  href={ISSUE_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1.5 text-[11px] font-bold text-blue-400 hover:text-blue-300"
+                >
+                  <ExternalLink size={11} />
+                  Owner, plan, and risk-acceptance details — see GitHub issue #238
+                </a>
+              </div>
+            </div>
           </Section>
         )}
 

--- a/src/components/trust/KSIFailureDashboard.jsx
+++ b/src/components/trust/KSIFailureDashboard.jsx
@@ -242,7 +242,18 @@ const DetailDrawer = ({ failure, isActive, onClose, allHistory }) => {
                     <section className="grid grid-cols-3 gap-3">
                         <div className="bg-[#1a1a1f] border border-white/5 rounded-xl p-4 text-center">
                             <div className="text-[9px] text-slate-500 uppercase tracking-wider mb-1">Score</div>
-                            <div className={`text-2xl font-black ${failure.score === 0 ? 'text-red-400' : failure.score < 50 ? 'text-amber-400' : 'text-emerald-400'}`}>{failure.score ?? 'N/A'}{failure.score != null && <span className="text-sm">%</span>}</div>
+                            {(() => {
+                                // Mode-aware threshold: Output-mode KSIs (e.g. KSI-TPR-04) pass at >=95%,
+                                // Capability-mode KSIs are binary 100/0. Without mode, default to capability.
+                                const target = failure.mode === 'output' ? 95 : 100;
+                                const scoreClass = failure.score == null ? 'text-slate-400'
+                                    : failure.score === 0 ? 'text-red-400'
+                                    : failure.score < target ? 'text-amber-400'
+                                    : 'text-emerald-400';
+                                return (
+                                    <div className={`text-2xl font-black ${scoreClass}`}>{failure.score ?? 'N/A'}{failure.score != null && <span className="text-sm">%</span>}</div>
+                                );
+                            })()}
                         </div>
                         <div className="bg-[#1a1a1f] border border-white/5 rounded-xl p-4 text-center">
                             <div className="text-[9px] text-slate-500 uppercase tracking-wider mb-1">Resources Failed</div>

--- a/src/components/trust/RemediationHeatmap.jsx
+++ b/src/components/trust/RemediationHeatmap.jsx
@@ -1,0 +1,66 @@
+/**
+ * Remediation Heatmap — single-row severity strip for the dashboard header.
+ * Reads remediation_backlog.json severity_counts. Each tile navigates to the
+ * Remediation Register filtered by that severity.
+ */
+import React from 'react';
+import { useData } from '../../hooks/useData';
+import { AlertOctagon, AlertTriangle, AlertCircle, Info } from 'lucide-react';
+
+const TILES = [
+  { key: 'CRITICAL', label: 'Critical', icon: AlertOctagon, dot: 'bg-red-500',    text: 'text-red-400',    bg: 'bg-red-500/5',    border: 'border-red-500/20',    hover: 'hover:border-red-500/40' },
+  { key: 'HIGH',     label: 'High',     icon: AlertTriangle, dot: 'bg-orange-500', text: 'text-orange-400', bg: 'bg-orange-500/5', border: 'border-orange-500/20', hover: 'hover:border-orange-500/40' },
+  { key: 'MEDIUM',   label: 'Medium',   icon: AlertCircle,   dot: 'bg-yellow-500', text: 'text-yellow-400', bg: 'bg-yellow-500/5', border: 'border-yellow-500/20', hover: 'hover:border-yellow-500/40' },
+  { key: 'LOW',      label: 'Low',      icon: Info,          dot: 'bg-blue-500',   text: 'text-blue-400',   bg: 'bg-blue-500/5',   border: 'border-blue-500/20',   hover: 'hover:border-blue-500/40' },
+];
+
+export const RemediationHeatmap = ({ onSelectSeverity }) => {
+  const { backlog } = useData();
+  if (!backlog) return null;
+
+  const counts = backlog.severity_counts || {};
+  const total = backlog.total_items ?? Object.values(counts).reduce((a, b) => a + (b || 0), 0);
+
+  return (
+    <div className="border border-white/5 rounded-xl bg-[#0c0c10] overflow-hidden">
+      <div className="px-4 py-2.5 border-b border-white/5 bg-white/[0.02] flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] font-bold uppercase tracking-wider text-slate-400">Remediation Backlog</span>
+          <span className="text-[10px] text-slate-500">{total} actionable</span>
+        </div>
+        <button
+          onClick={() => onSelectSeverity?.(null)}
+          className="text-[10px] font-bold uppercase tracking-wider text-blue-400 hover:text-blue-300"
+        >
+          Open Register →
+        </button>
+      </div>
+      <div className="grid grid-cols-2 lg:grid-cols-4 divide-x divide-white/5">
+        {TILES.map(tile => {
+          const Icon = tile.icon;
+          const count = counts[tile.key] ?? 0;
+          return (
+            <button
+              key={tile.key}
+              onClick={() => onSelectSeverity?.(tile.key)}
+              className={`p-4 transition-colors text-left ${tile.bg} ${tile.border} ${tile.hover} border-0 group`}
+            >
+              <div className="flex items-center justify-between mb-1">
+                <div className="flex items-center gap-2">
+                  <span className={`w-1.5 h-1.5 rounded-full ${tile.dot}`} />
+                  <span className="text-[9px] font-bold uppercase tracking-wider text-slate-400 group-hover:text-slate-300">{tile.label}</span>
+                </div>
+                <Icon size={12} className={`${tile.text} opacity-60`} />
+              </div>
+              <div className={`text-2xl font-black tabular-nums ${count > 0 ? tile.text : 'text-slate-600'}`}>
+                {count}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default RemediationHeatmap;

--- a/src/components/trust/RemediationRegister.jsx
+++ b/src/components/trust/RemediationRegister.jsx
@@ -1,0 +1,473 @@
+/**
+ * Remediation Register — FedRAMP 20x Continuous Remediation Register
+ *
+ * Reads remediation_backlog.json (public schema). Surfaces actionable findings
+ * from the engine's resource-level evaluations as a sortable, filterable
+ * table — the operational PoAM-equivalent for the trust center.
+ *
+ * Public schema constraints (engine-enforced redaction):
+ *   - No raw resource names — only opaque "[r-<6char>]" hashes (stable for grouping)
+ *   - No owner, no remediation_plan, no risk_acceptance text
+ *   - reason text is either redacted-with-context or a per-KSI category fallback
+ *
+ * For specifics, deep details live on GitHub issue #238 in the submission repo.
+ */
+import React, { useState, useMemo, useEffect } from 'react';
+import { useData } from '../../hooks/useData';
+import {
+  Search, X, ChevronDown, ChevronRight, AlertOctagon,
+  AlertTriangle, AlertCircle, Info, Clock, ExternalLink,
+  Shield, Layers, Hash, Filter
+} from 'lucide-react';
+
+const ISSUE_URL = 'https://github.com/Meridian-Knowledge-Solutions/fedramp-20x-submission-final/issues/238';
+
+const SEVERITY_ORDER = { CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3 };
+const STATE_ORDER = { OPEN: 0, IN_PROGRESS: 1, RISK_ACCEPTED: 2, CLOSED: 3 };
+
+const severityConfig = {
+  CRITICAL: { dot: 'bg-red-500', text: 'text-red-400', bg: 'bg-red-500/10', border: 'border-red-500/30', icon: AlertOctagon },
+  HIGH:     { dot: 'bg-orange-500', text: 'text-orange-400', bg: 'bg-orange-500/10', border: 'border-orange-500/30', icon: AlertTriangle },
+  MEDIUM:   { dot: 'bg-yellow-500', text: 'text-yellow-400', bg: 'bg-yellow-500/10', border: 'border-yellow-500/30', icon: AlertCircle },
+  LOW:      { dot: 'bg-blue-500', text: 'text-blue-400', bg: 'bg-blue-500/10', border: 'border-blue-500/30', icon: Info },
+};
+
+const stateConfig = {
+  OPEN:          { text: 'text-slate-300', bg: 'bg-slate-500/10', border: 'border-slate-500/30', label: 'OPEN' },
+  IN_PROGRESS:   { text: 'text-blue-300', bg: 'bg-blue-500/10', border: 'border-blue-500/30', label: 'IN PROGRESS' },
+  RISK_ACCEPTED: { text: 'text-purple-300', bg: 'bg-purple-500/10', border: 'border-purple-500/30', label: 'RISK ACCEPTED' },
+  CLOSED:        { text: 'text-emerald-300', bg: 'bg-emerald-500/10', border: 'border-emerald-500/30', label: 'CLOSED' },
+};
+
+const STALE_DAYS = 30;
+
+const daysSince = (iso) => {
+  if (!iso) return null;
+  const ms = Date.now() - new Date(iso).getTime();
+  if (Number.isNaN(ms)) return null;
+  return Math.floor(ms / 86400000);
+};
+
+const ageLabel = (iso) => {
+  const d = daysSince(iso);
+  if (d == null) return '—';
+  if (d === 0) return 'today';
+  if (d === 1) return '1d';
+  return `${d}d`;
+};
+
+const formatDate = (iso) => {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  } catch { return '—'; }
+};
+
+const SeverityChip = ({ severity }) => {
+  const cfg = severityConfig[severity] || severityConfig.LOW;
+  return (
+    <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider border ${cfg.bg} ${cfg.text} ${cfg.border}`}>
+      <span className={`w-1.5 h-1.5 rounded-full ${cfg.dot}`} />
+      {severity}
+    </span>
+  );
+};
+
+const StateChip = ({ state }) => {
+  const cfg = stateConfig[state] || stateConfig.OPEN;
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider border ${cfg.bg} ${cfg.text} ${cfg.border}`}>
+      {cfg.label}
+    </span>
+  );
+};
+
+const StaleBadge = ({ firstSeen, state }) => {
+  if (state !== 'OPEN') return null;
+  const d = daysSince(firstSeen);
+  if (d == null || d < STALE_DAYS) return null;
+  return (
+    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[9px] font-bold uppercase tracking-wider border border-amber-500/30 bg-amber-500/10 text-amber-300">
+      <Clock size={9} /> Stale {d}d
+    </span>
+  );
+};
+
+const FilterPill = ({ label, count, active, onClick, color }) => (
+  <button
+    onClick={onClick}
+    className={`px-3 py-1.5 rounded-md text-[11px] font-bold transition-all whitespace-nowrap flex items-center gap-2 border ${
+      active
+        ? 'bg-white/10 text-white border-white/20'
+        : 'bg-transparent text-slate-400 border-transparent hover:text-white hover:bg-white/5'
+    }`}
+  >
+    {color && <span className={`w-1.5 h-1.5 rounded-full ${color}`} />}
+    {label}
+    {count != null && (
+      <span className={`px-1.5 py-0.5 rounded-full text-[10px] ${active ? 'bg-black/30 text-slate-200' : 'bg-white/5 text-slate-500'}`}>
+        {count}
+      </span>
+    )}
+  </button>
+);
+
+const Row = ({ item }) => {
+  const [open, setOpen] = useState(false);
+  const sev = severityConfig[item.severity] || severityConfig.LOW;
+  const SevIcon = sev.icon;
+
+  return (
+    <>
+      <tr
+        onClick={() => setOpen(o => !o)}
+        className="border-b border-white/5 hover:bg-white/[0.02] cursor-pointer transition-colors"
+      >
+        <td className="px-3 py-2.5 align-middle">
+          <div className="flex items-center gap-2">
+            {open ? <ChevronDown size={12} className="text-slate-500" /> : <ChevronRight size={12} className="text-slate-500" />}
+            <SevIcon size={12} className={sev.text} />
+            <SeverityChip severity={item.severity} />
+          </div>
+        </td>
+        <td className="px-3 py-2.5 align-middle font-mono text-[11px] text-white">{item.ksi}</td>
+        <td className="px-3 py-2.5 align-middle font-mono text-[11px] text-slate-400">{item.resource}</td>
+        <td className="px-3 py-2.5 align-middle">
+          <div className="flex items-center gap-2">
+            <StateChip state={item.tracking?.state || 'OPEN'} />
+            <StaleBadge firstSeen={item.first_seen} state={item.tracking?.state} />
+          </div>
+        </td>
+        <td className="px-3 py-2.5 align-middle text-[11px] text-slate-300 font-mono tabular-nums">
+          {item.tracking?.target_date || '—'}
+        </td>
+        <td className="px-3 py-2.5 align-middle text-[11px] text-slate-400 font-mono tabular-nums">
+          {ageLabel(item.first_seen)}
+        </td>
+        <td className="px-3 py-2.5 align-middle font-mono text-[10px] text-slate-500">{item.id}</td>
+      </tr>
+      {open && (
+        <tr className="bg-black/30">
+          <td colSpan={7} className="px-6 py-4 border-b border-white/5">
+            <div className="space-y-3 text-[12px]">
+              <div>
+                <div className="text-[9px] uppercase tracking-wider font-bold text-slate-500 mb-1">Reason</div>
+                <p className="text-slate-300 leading-relaxed font-mono">{item.reason || '—'}</p>
+              </div>
+              <div className="flex flex-wrap gap-x-6 gap-y-2 text-[11px]">
+                <div>
+                  <span className="text-[9px] uppercase tracking-wider font-bold text-slate-500 mr-2">First seen</span>
+                  <span className="text-slate-300 font-mono">{formatDate(item.first_seen)}</span>
+                </div>
+                <div>
+                  <span className="text-[9px] uppercase tracking-wider font-bold text-slate-500 mr-2">Last seen</span>
+                  <span className="text-slate-300 font-mono">{formatDate(item.last_seen)}</span>
+                </div>
+                <div>
+                  <span className="text-[9px] uppercase tracking-wider font-bold text-slate-500 mr-2">Status</span>
+                  <span className="text-slate-300 font-mono">{item.status || '—'}</span>
+                </div>
+              </div>
+              <div className="pt-2 border-t border-white/5">
+                <a
+                  href={ISSUE_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1.5 text-[11px] font-bold text-blue-400 hover:text-blue-300"
+                >
+                  <ExternalLink size={11} />
+                  Owner, plan, and risk-acceptance details — see GitHub issue #238
+                </a>
+              </div>
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+};
+
+export const RemediationRegister = ({ initialFilters = {} }) => {
+  const { backlog, loading } = useData();
+  const [search, setSearch] = useState('');
+  const [severityFilter, setSeverityFilter] = useState(initialFilters.severity || 'all');
+  const [stateFilter, setStateFilter] = useState(initialFilters.state || 'all');
+  const [ksiFilter, setKsiFilter] = useState(initialFilters.ksi || 'all');
+  const [groupByResource, setGroupByResource] = useState(false);
+
+  // Re-apply incoming filters when navigation changes them (e.g. heatmap click).
+  useEffect(() => {
+    if (initialFilters.severity) setSeverityFilter(initialFilters.severity);
+    if (initialFilters.state) setStateFilter(initialFilters.state);
+    if (initialFilters.ksi) setKsiFilter(initialFilters.ksi);
+  }, [initialFilters.severity, initialFilters.state, initialFilters.ksi]);
+
+  const items = backlog?.items || [];
+
+  const counts = useMemo(() => {
+    const sev = { CRITICAL: 0, HIGH: 0, MEDIUM: 0, LOW: 0 };
+    const st = { OPEN: 0, IN_PROGRESS: 0, RISK_ACCEPTED: 0, CLOSED: 0 };
+    for (const it of items) {
+      if (sev[it.severity] != null) sev[it.severity]++;
+      const s = it.tracking?.state || 'OPEN';
+      if (st[s] != null) st[s]++;
+    }
+    return { severity: sev, state: st };
+  }, [items]);
+
+  const ksiOptions = useMemo(() => {
+    const set = new Set(items.map(i => i.ksi).filter(Boolean));
+    return ['all', ...Array.from(set).sort()];
+  }, [items]);
+
+  const filtered = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    return items.filter(it => {
+      if (severityFilter !== 'all' && it.severity !== severityFilter) return false;
+      if (stateFilter !== 'all' && (it.tracking?.state || 'OPEN') !== stateFilter) return false;
+      if (ksiFilter !== 'all' && it.ksi !== ksiFilter) return false;
+      if (term) {
+        const hay = `${it.id} ${it.ksi} ${it.resource} ${it.reason}`.toLowerCase();
+        if (!hay.includes(term)) return false;
+      }
+      return true;
+    }).sort((a, b) => {
+      const sevA = SEVERITY_ORDER[a.severity] ?? 9;
+      const sevB = SEVERITY_ORDER[b.severity] ?? 9;
+      if (sevA !== sevB) return sevA - sevB;
+      const stA = STATE_ORDER[a.tracking?.state || 'OPEN'] ?? 9;
+      const stB = STATE_ORDER[b.tracking?.state || 'OPEN'] ?? 9;
+      if (stA !== stB) return stA - stB;
+      return new Date(a.first_seen).getTime() - new Date(b.first_seen).getTime();
+    });
+  }, [items, search, severityFilter, stateFilter, ksiFilter]);
+
+  const resourceGroups = useMemo(() => {
+    if (!groupByResource) return null;
+    const groups = {};
+    for (const it of filtered) {
+      const key = it.resource || '(unknown)';
+      if (!groups[key]) groups[key] = { resource: key, items: [], ksis: new Set() };
+      groups[key].items.push(it);
+      groups[key].ksis.add(it.ksi);
+    }
+    return Object.values(groups).sort((a, b) => b.items.length - a.items.length);
+  }, [filtered, groupByResource]);
+
+  const handleResetFilters = () => {
+    setSearch('');
+    setSeverityFilter('all');
+    setStateFilter('all');
+    setKsiFilter('all');
+  };
+
+  if (loading) {
+    return <div className="p-12 text-center text-slate-500">Loading remediation register...</div>;
+  }
+
+  if (!backlog) {
+    return (
+      <div className="border border-white/5 rounded-xl bg-[#0c0c10] p-12 text-center">
+        <Shield size={32} className="text-slate-600 mx-auto mb-3" />
+        <h3 className="font-bold text-white text-lg mb-2">Remediation Register Not Yet Published</h3>
+        <p className="text-sm text-slate-400 max-w-md mx-auto">
+          The engine has not yet published <code className="text-xs text-slate-300 bg-white/5 px-1.5 py-0.5 rounded">remediation_backlog.json</code> to the trust-center data path.
+          This file is generated by the FedRAMP 20x continuous remediation register pipeline.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 animate-in fade-in duration-500">
+
+      {/* Header */}
+      <div className="border border-white/5 rounded-xl bg-[#0c0c10] p-5">
+        <div className="flex flex-col lg:flex-row items-start lg:items-center justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-3 mb-1">
+              <div className="p-2 rounded-lg bg-blue-500/10 border border-blue-500/20">
+                <Layers size={18} className="text-blue-400" />
+              </div>
+              <h2 className="text-xl font-bold text-white tracking-tight">Remediation Register</h2>
+              <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500 border border-white/5 px-2 py-0.5 rounded bg-white/5">
+                FedRAMP 20x · Public
+              </span>
+            </div>
+            <p className="text-xs text-slate-500">
+              {backlog.total_items} actionable items
+              {backlog.filtered_info_count > 0 && <> · {backlog.filtered_info_count} INFO-tier filtered</>}
+              {backlog.generated_at && <> · Generated {formatDate(backlog.generated_at)}</>}
+            </p>
+          </div>
+          <a
+            href={ISSUE_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 text-[11px] font-bold text-blue-400 hover:text-blue-300 px-3 py-1.5 rounded border border-blue-500/20 bg-blue-500/5"
+          >
+            <ExternalLink size={11} />
+            Operational details
+          </a>
+        </div>
+        {backlog.note && (
+          <p className="text-[11px] text-slate-500 mt-3 pt-3 border-t border-white/5 leading-relaxed">{backlog.note}</p>
+        )}
+      </div>
+
+      {/* Filter bar */}
+      <div className="border border-white/5 rounded-xl bg-[#0c0c10] p-4 space-y-3">
+        {/* Search */}
+        <div className="flex flex-col sm:flex-row gap-3">
+          <div className="relative flex-1">
+            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" />
+            <input
+              type="text"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              placeholder="Search by ID, KSI, resource hash, or reason..."
+              className="w-full pl-9 pr-9 py-2 bg-white/5 border border-white/5 rounded-lg text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:border-blue-500/40"
+            />
+            {search && (
+              <button onClick={() => setSearch('')} className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300">
+                <X size={14} />
+              </button>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setGroupByResource(g => !g)}
+              className={`px-3 py-2 rounded-lg text-[11px] font-bold transition-colors flex items-center gap-2 border ${
+                groupByResource
+                  ? 'bg-blue-500/10 border-blue-500/30 text-blue-300'
+                  : 'bg-white/5 border-white/5 text-slate-400 hover:text-white'
+              }`}
+            >
+              <Hash size={11} /> Group by resource
+            </button>
+            <button
+              onClick={handleResetFilters}
+              className="px-3 py-2 rounded-lg text-[11px] font-bold text-slate-400 hover:text-white bg-white/5 border border-white/5 transition-colors"
+            >
+              Reset
+            </button>
+          </div>
+        </div>
+
+        {/* Severity filters */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-[10px] uppercase tracking-wider font-bold text-slate-500 mr-2 flex items-center gap-1.5">
+            <Filter size={10} /> Severity
+          </span>
+          <FilterPill label="All" count={items.length} active={severityFilter === 'all'} onClick={() => setSeverityFilter('all')} />
+          {['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'].map(sev => (
+            <FilterPill
+              key={sev}
+              label={sev}
+              count={counts.severity[sev]}
+              active={severityFilter === sev}
+              color={severityConfig[sev].dot}
+              onClick={() => setSeverityFilter(severityFilter === sev ? 'all' : sev)}
+            />
+          ))}
+        </div>
+
+        {/* State filters */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-[10px] uppercase tracking-wider font-bold text-slate-500 mr-2 flex items-center gap-1.5">
+            <Filter size={10} /> State
+          </span>
+          <FilterPill label="All" active={stateFilter === 'all'} onClick={() => setStateFilter('all')} />
+          {['OPEN', 'IN_PROGRESS', 'RISK_ACCEPTED', 'CLOSED'].map(s => (
+            <FilterPill
+              key={s}
+              label={stateConfig[s].label}
+              count={counts.state[s]}
+              active={stateFilter === s}
+              onClick={() => setStateFilter(stateFilter === s ? 'all' : s)}
+            />
+          ))}
+        </div>
+
+        {/* KSI dropdown — only show when there are many */}
+        {ksiOptions.length > 4 && (
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] uppercase tracking-wider font-bold text-slate-500 mr-1 flex items-center gap-1.5">
+              <Filter size={10} /> KSI
+            </span>
+            <select
+              value={ksiFilter}
+              onChange={e => setKsiFilter(e.target.value)}
+              className="px-3 py-1.5 bg-white/5 border border-white/5 rounded-lg text-[11px] font-bold text-slate-300 focus:outline-none focus:border-blue-500/40"
+            >
+              {ksiOptions.map(k => (
+                <option key={k} value={k}>{k === 'all' ? 'All KSIs' : k}</option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+
+      {/* Result count */}
+      <div className="flex items-center justify-between text-[11px] text-slate-500">
+        <span>
+          Showing {filtered.length} of {items.length} items
+        </span>
+        {(severityFilter !== 'all' || stateFilter !== 'all' || ksiFilter !== 'all' || search) && (
+          <button onClick={handleResetFilters} className="text-blue-400 hover:text-blue-300 font-bold">
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      {/* Table */}
+      {filtered.length === 0 ? (
+        <div className="border-2 border-dashed border-white/5 rounded-xl py-16 text-center text-slate-500">
+          No items match the current filters.
+        </div>
+      ) : groupByResource && resourceGroups ? (
+        <div className="space-y-3">
+          {resourceGroups.map(g => (
+            <div key={g.resource} className="border border-white/5 rounded-xl overflow-hidden bg-[#0c0c10]">
+              <div className="px-4 py-3 border-b border-white/5 bg-white/[0.02] flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <Hash size={12} className="text-slate-500" />
+                  <span className="font-mono text-[12px] text-white font-bold">{g.resource}</span>
+                  <span className="text-[10px] text-slate-500">
+                    {g.items.length} finding{g.items.length === 1 ? '' : 's'} · {g.ksis.size} KSI{g.ksis.size === 1 ? '' : 's'}
+                  </span>
+                </div>
+              </div>
+              <table className="w-full">
+                <tbody>
+                  {g.items.map(item => <Row key={item.id} item={item} />)}
+                </tbody>
+              </table>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="border border-white/5 rounded-xl overflow-hidden bg-[#0c0c10]">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-white/5 bg-white/[0.02] text-[9px] uppercase tracking-wider font-bold text-slate-500 text-left">
+                <th className="px-3 py-2.5">Severity</th>
+                <th className="px-3 py-2.5">KSI</th>
+                <th className="px-3 py-2.5">Resource</th>
+                <th className="px-3 py-2.5">State</th>
+                <th className="px-3 py-2.5">Target</th>
+                <th className="px-3 py-2.5">Age</th>
+                <th className="px-3 py-2.5">ID</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map(item => <Row key={item.id} item={item} />)}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RemediationRegister;

--- a/src/components/trust/RemediationRegister.jsx
+++ b/src/components/trust/RemediationRegister.jsx
@@ -9,18 +9,14 @@
  *   - No raw resource names — only opaque "[r-<6char>]" hashes (stable for grouping)
  *   - No owner, no remediation_plan, no risk_acceptance text
  *   - reason text is either redacted-with-context or a per-KSI category fallback
- *
- * For specifics, deep details live on GitHub issue #238 in the submission repo.
  */
 import React, { useState, useMemo, useEffect } from 'react';
 import { useData } from '../../hooks/useData';
 import {
   Search, X, ChevronDown, ChevronRight, AlertOctagon,
-  AlertTriangle, AlertCircle, Info, Clock, ExternalLink,
+  AlertTriangle, AlertCircle, Info, Clock,
   Shield, Layers, Hash, Filter
 } from 'lucide-react';
-
-const ISSUE_URL = 'https://github.com/Meridian-Knowledge-Solutions/fedramp-20x-submission-final/issues/238';
 
 const SEVERITY_ORDER = { CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3 };
 const STATE_ORDER = { OPEN: 0, IN_PROGRESS: 1, RISK_ACCEPTED: 2, CLOSED: 3 };
@@ -168,17 +164,6 @@ const Row = ({ item }) => {
                   <span className="text-slate-300 font-mono">{item.status || '—'}</span>
                 </div>
               </div>
-              <div className="pt-2 border-t border-white/5">
-                <a
-                  href={ISSUE_URL}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-1.5 text-[11px] font-bold text-blue-400 hover:text-blue-300"
-                >
-                  <ExternalLink size={11} />
-                  Owner, plan, and risk-acceptance details — see GitHub issue #238
-                </a>
-              </div>
             </div>
           </td>
         </tr>
@@ -300,15 +285,6 @@ export const RemediationRegister = ({ initialFilters = {} }) => {
               {backlog.generated_at && <> · Generated {formatDate(backlog.generated_at)}</>}
             </p>
           </div>
-          <a
-            href={ISSUE_URL}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-1.5 text-[11px] font-bold text-blue-400 hover:text-blue-300 px-3 py-1.5 rounded border border-blue-500/20 bg-blue-500/5"
-          >
-            <ExternalLink size={11} />
-            Operational details
-          </a>
         </div>
         {backlog.note && (
           <p className="text-[11px] text-slate-500 mt-3 pt-3 border-t border-white/5 leading-relaxed">{backlog.note}</p>

--- a/src/hooks/useData.jsx
+++ b/src/hooks/useData.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, useRef, useCallback } from 'react';
+import React, { createContext, useContext, useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Sanitizer } from '../utils/sanitizer';
 
 const DataContext = createContext();
@@ -25,6 +25,7 @@ export const DataProvider = ({ children }) => {
   const [history, setHistory] = useState([]);
   const [masData, setMasData] = useState(null);
   const [metricsData, setMetricsData] = useState(null);
+  const [backlog, setBacklog] = useState(null);
   const [metrics, setMetrics] = useState({
     score: 0, passed: 0, failed: 0, meets_threshold: 0, warning: 0, info: 0
   });
@@ -124,17 +125,43 @@ export const DataProvider = ({ children }) => {
         register: `${BASE_PATH}cli_command_register.json?t=${cacheBuster}`, // Synced from private repo via pipeline
         history: `${BASE_PATH}ksi_history.jsonl?t=${cacheBuster}`,
         mas: `${BASE_PATH}mas_boundary.json?t=${cacheBuster}`,
-        metricsHistory: `${BASE_PATH}metrics_history.jsonl?t=${cacheBuster}`
+        metricsHistory: `${BASE_PATH}metrics_history.jsonl?t=${cacheBuster}`,
+        backlog: `${BASE_PATH}remediation_backlog.json?t=${cacheBuster}`
       };
 
       // 1. Fetch All Data Sources
-      const [valRes, regRes, histRes, masRes, metricsRes] = await Promise.all([
+      const [valRes, regRes, histRes, masRes, metricsRes, backlogRes] = await Promise.all([
         fetch(urls.validations),
         fetch(urls.register),
         fetch(urls.history),
         fetch(urls.mas),
-        fetch(urls.metricsHistory)
+        fetch(urls.metricsHistory),
+        fetch(urls.backlog)
       ]);
+
+      // --- REMEDIATION BACKLOG (FedRAMP 20x continuous remediation register) ---
+      // Public schema — opaque resource hashes, no owner/plan/risk-acceptance text.
+      if (backlogRes.ok) {
+        try {
+          const text = await backlogRes.text();
+          if (!text.trim().startsWith('<')) {
+            setBacklog(JSON.parse(text));
+            console.log("✅ Remediation Backlog Loaded");
+          } else {
+            console.warn("⚠️ Remediation Backlog returned HTML (likely 404)");
+            setBacklog(null);
+          }
+        } catch (e) {
+          console.warn("⚠️ Failed to parse Remediation Backlog:", e);
+          setBacklog(null);
+        }
+      } else {
+        // Backlog file is optional — engine may not have published it yet.
+        if (backlogRes.status !== 404) {
+          console.warn(`⚠️ Remediation Backlog Fetch Failed: ${backlogRes.status}`);
+        }
+        setBacklog(null);
+      }
 
       // --- MAS DATA PROCESSING (WITH DEBUGGING) ---
       if (masRes.ok) {
@@ -388,6 +415,34 @@ export const DataProvider = ({ children }) => {
     loadData();
   }, [loadData]);
 
+  // Per-KSI backlog index — derived once per backlog change so KSI cards,
+  // the Why modal, and the register can all consume without recomputing.
+  const backlogByKsi = useMemo(() => {
+    const idx = {};
+    if (!backlog?.items) return idx;
+    for (const it of backlog.items) {
+      const k = it.ksi;
+      if (!k) continue;
+      if (!idx[k]) {
+        idx[k] = {
+          items: [],
+          severityCounts: { CRITICAL: 0, HIGH: 0, MEDIUM: 0, LOW: 0 },
+          stateCounts: { OPEN: 0, IN_PROGRESS: 0, RISK_ACCEPTED: 0, CLOSED: 0 },
+          hasRiskAccepted: false,
+          openCount: 0,
+        };
+      }
+      const bucket = idx[k];
+      bucket.items.push(it);
+      if (bucket.severityCounts[it.severity] != null) bucket.severityCounts[it.severity]++;
+      const state = it.tracking?.state || 'OPEN';
+      if (bucket.stateCounts[state] != null) bucket.stateCounts[state]++;
+      if (state === 'RISK_ACCEPTED') bucket.hasRiskAccepted = true;
+      if (state === 'OPEN' || state === 'IN_PROGRESS') bucket.openCount++;
+    }
+    return idx;
+  }, [backlog]);
+
   // Auto-refresh logic
   useEffect(() => {
     const settings = JSON.parse(localStorage.getItem('trustCenterSettings') || '{"autoRefresh": true}');
@@ -407,7 +462,7 @@ export const DataProvider = ({ children }) => {
   }, [loadData]);
 
   return (
-    <DataContext.Provider value={{ ksis, metrics, metadata, history, masData, metricsData, loading, reload: loadData }}>
+    <DataContext.Provider value={{ ksis, metrics, metadata, history, masData, metricsData, backlog, backlogByKsi, loading, reload: loadData }}>
       {children}
     </DataContext.Provider>
   );


### PR DESCRIPTION
## Summary
Introduces the FedRAMP 20x Continuous Remediation Register—a public-schema operational PoAM equivalent that surfaces actionable findings from the engine's resource-level evaluations. Adds a new `RemediationRegister` component with sortable/filterable table view, a `RemediationHeatmap` severity strip for the dashboard, and integrates remediation backlog data throughout the trust center.

## Key Changes

### New Components
- **`RemediationRegister.jsx`** — Full-featured remediation register table with:
  - Sortable/filterable findings by severity, state, and KSI
  - Expandable rows showing reason, dates, and status details
  - Optional grouping by resource hash
  - Stale finding detection (30+ days in OPEN state)
  - Public schema constraints: opaque resource hashes `[r-<6char>]`, no owner/plan/risk-acceptance text
  
- **`RemediationHeatmap.jsx`** — Dashboard header severity strip showing:
  - CRITICAL/HIGH/MEDIUM/LOW counts from `remediation_backlog.json`
  - Clickable tiles that navigate to the register pre-filtered by severity

### Integration Points
- **`useData.jsx`** — Added backlog data loading and per-KSI indexing:
  - Fetches `remediation_backlog.json` from the trust-center data path
  - Derives `backlogByKsi` index for efficient KSI-level lookups
  - Gracefully handles missing backlog (optional file, engine-dependent)
  
- **`WhyModal.jsx`** — Surfaces remediation backlog items linked to each KSI:
  - Shows up to 25 backlog items with severity/state/resource/reason
  - Quick severity breakdown with color-coded chips
  - Links to full register for complete list
  
- **`KSIGrid.jsx`** — Passes backlog stats to KSI cards:
  - Added `ModeChip` component to distinguish Capability-mode vs Output-mode KSIs
  - Enables future backlog indicators on cards
  
- **`App.jsx`** — Wired register navigation:
  - Added `RemediationRegister` view with filter state management
  - Integrated `RemediationHeatmap` into dashboard
  - Heatmap severity clicks pre-filter the register

### Data Schema
Remediation backlog follows public schema constraints (engine-enforced redaction):
- Resource names redacted to opaque `[r-<6char>]` hashes (stable for grouping)
- No owner, remediation_plan, or risk_acceptance text
- Reason text is either redacted-with-context or per-KSI category fallback
- Includes severity, state (OPEN/IN_PROGRESS/RISK_ACCEPTED/CLOSED), first_seen, last_seen, target_date

## Notable Implementation Details
- **Stale detection**: Findings in OPEN state for 30+ days are flagged with age badge
- **Severity ordering**: CRITICAL → HIGH → MEDIUM → LOW, with secondary sort by state and age
- **Mode awareness**: KSI cards now distinguish between Capability-mode (system presence + capability_status) and Output-mode (rate vs 95% target) per FedRAMP 20x outcome framework
- **Graceful degradation**: Register and heatmap only render if backlog is published; missing file doesn't break the UI
- **Performance**: Per-KSI backlog index memoized to avoid recomputation across components

https://claude.ai/code/session_0178Qz519DqVAAUrw3ntwfpL