### PR TITLE
Trust Center: header freshness badge reflects last KSI validation run

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -526,12 +526,17 @@ const AppShell = () => {
     return onRouteChange(sync);
   }, []);
 
-  // Site-wide data freshness signal (continuous-monitoring "last refreshed").
+  // Site-wide data freshness signal — the timestamp of the last continuous-
+  // monitoring run. Sourced from vdr_public_metrics.json (metadata.generated_at),
+  // which the pipeline rewrites on every run, so it always reflects the last run.
   useEffect(() => {
     let cancelled = false;
-    fetch(`${import.meta.env.BASE_URL}data/next_report_date.json`)
+    fetch(`${import.meta.env.BASE_URL}data/vdr_public_metrics.json`)
       .then(r => (r.ok ? r.json() : null))
-      .then(j => { if (!cancelled && j) setFreshness(j.last_data_refresh || j.last_report_generated || null); })
+      .then(j => {
+        const ts = j?.metadata?.generated_at || j?.snapshot?.timestamp;
+        if (!cancelled && ts) setFreshness(ts);
+      })
       .catch(() => {});
     return () => { cancelled = true; };
   }, []);
@@ -852,14 +857,14 @@ const AppShell = () => {
           <div className="flex items-center space-x-3 lg:space-x-6">
             {freshness && (
               <div className="hidden sm:flex items-center gap-2 px-3 py-1.5 rounded-lg bg-emerald-500/5 border border-emerald-500/15"
-                   title="Continuous monitoring — data refreshed on this date; Key Security Indicators re-validate every 4 hours.">
+                   title={`Continuous monitoring — last validation run ${new Date(freshness).toLocaleString()}. Key Security Indicators re-validate every 4 hours.`}>
                 <span className="relative flex h-2 w-2">
                   <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-60" />
                   <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
                 </span>
                 <div className="leading-tight">
                   <div className="text-[8px] text-slate-500 uppercase font-bold tracking-wider">Continuous Monitoring</div>
-                  <div className="text-[10px] text-emerald-300 font-mono">Updated {freshness}</div>
+                  <div className="text-[10px] text-emerald-300 font-mono">Last run {getTimeElapsed(new Date(freshness))}</div>
                 </div>
               </div>
             )}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -502,11 +502,14 @@ const AppShell = () => {
   });
   const [registerFilters, setRegisterFilters] = useState({});
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [freshness, setFreshness] = useState(null);
   const scrollY = useScrollPosition();
 
   const { user, isAuthenticated, logout } = useAuth();
   const { openModal } = useModal();
+  // Header freshness = timestamp of the last KSI continuous-validation run,
+  // already loaded by DataProvider (unified_ksi_validations.json metadata).
+  const { metadata } = useData();
+  const freshness = metadata?.validation_date || null;
 
   // User-initiated navigation: update state AND the URL hash (top-level views
   // reset any deeper tab/section so the link reflects where you are).
@@ -524,21 +527,6 @@ const AppShell = () => {
       if (KNOWN_VIEWS.has(seg)) setActiveView(seg);
     };
     return onRouteChange(sync);
-  }, []);
-
-  // Site-wide data freshness signal — the timestamp of the last continuous-
-  // monitoring run. Sourced from vdr_public_metrics.json (metadata.generated_at),
-  // which the pipeline rewrites on every run, so it always reflects the last run.
-  useEffect(() => {
-    let cancelled = false;
-    fetch(`${import.meta.env.BASE_URL}data/vdr_public_metrics.json`)
-      .then(r => (r.ok ? r.json() : null))
-      .then(j => {
-        const ts = j?.metadata?.generated_at || j?.snapshot?.timestamp;
-        if (!cancelled && ts) setFreshness(ts);
-      })
-      .catch(() => {});
-    return () => { cancelled = true; };
   }, []);
 
   // Navigate to the Remediation Register, optionally pre-filtered (e.g. heatmap click).
@@ -857,13 +845,13 @@ const AppShell = () => {
           <div className="flex items-center space-x-3 lg:space-x-6">
             {freshness && (
               <div className="hidden sm:flex items-center gap-2 px-3 py-1.5 rounded-lg bg-emerald-500/5 border border-emerald-500/15"
-                   title={`Continuous monitoring — last validation run ${new Date(freshness).toLocaleString()}. Key Security Indicators re-validate every 4 hours.`}>
+                   title={`Last KSI continuous-validation run: ${new Date(freshness).toLocaleString()}. Key Security Indicators re-validate every 4 hours.`}>
                 <span className="relative flex h-2 w-2">
                   <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-60" />
                   <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
                 </span>
                 <div className="leading-tight">
-                  <div className="text-[8px] text-slate-500 uppercase font-bold tracking-wider">Continuous Monitoring</div>
+                  <div className="text-[8px] text-slate-500 uppercase font-bold tracking-wider">KSI Validation</div>
                   <div className="text-[10px] text-emerald-300 font-mono">Last run {getTimeElapsed(new Date(freshness))}</div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Follow-up to #46. The global-header freshness badge showed a frozen date and was wired to the wrong data source. This makes it an accurate, self-updating signal of the **last KSI continuous-validation run**.

## Problem

- The badge fetched `vdr_public_metrics.json` (VDR metrics generation) but was labeled **"Continuous Monitoring"** — two different things. The timestamp shown didn't correspond to the KSI validation cadence the label implied.
- It also relied on a separate one-off `fetch()` whose source wasn't reliably refreshed, so the date looked stale.

## Change (`src/App.jsx`)

- **Source** — derive freshness from `metadata.validation_date`, which `DataProvider` already loads from `unified_ksi_validations.json`. No extra fetch; the badge now tracks the same file the pipeline rewrites on every KSI run, so it stays current.
- **Label** — "Continuous Monitoring" → **"KSI Validation"** so the badge is unambiguous about what it reports.
- **Tooltip** — updated to "Last KSI continuous-validation run: `<timestamp>`. Key Security Indicators re-validate every 4 hours."
- Removed the now-dead `freshness` state + `vdr_public_metrics.json` fetch effect.

Net: **-14 / +7** in `App.jsx`.

## Verification

- `vite build` compiles cleanly
- Badge still guards on a present timestamp and renders the relative "Last run …" string via `getTimeElapsed`
- Rebased onto latest `master` so the diff is `App.jsx` only (no data-sync churn)

https://claude.ai/code/session_01RohVympQBeGWU5PaWB6krd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RohVympQBeGWU5PaWB6krd)_