### PR TITLE
SCN view + console-aligned register form

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import {
   LayoutDashboard, ShieldAlert, User, LogOut,
   Menu, Activity, Calendar, Clock,
   FileText, RefreshCw, BarChart3, Eye, X, Shield, Layers,
-  BookOpen, Code2, FileBarChart, Database, ListTodo, Lock
+  BookOpen, Code2, FileBarChart, Database, ListTodo, Lock, Megaphone
 } from 'lucide-react';
 
 import {
@@ -31,6 +31,7 @@ import { SchemaTab } from './components/trust/SchemaTab';
 import { ReportsTab } from './components/trust/ReportsTab';
 import { RemediationRegister } from './components/trust/RemediationRegister';
 import { RemediationHeatmap } from './components/trust/RemediationHeatmap';
+import { ScnView } from './components/trust/ScnView';
 import { TrustCenterDataProvider } from './hooks/useTrustCenterData';
 
 import { THEME, BASE_PATH } from './config/theme';
@@ -323,13 +324,14 @@ const DashboardContent = memo(({ onOpenRegister }) => {
 // --- APP SHELL ---
 
 const KNOWN_VIEWS = new Set([
-  'dashboard', 'trust', 'vdr', 'transparency', 'metrics',
+  'dashboard', 'trust', 'scn', 'vdr', 'transparency', 'metrics',
   'failures', 'register', 'mas', 'policies', 'schema', 'reports',
 ]);
 
 const VIEW_TITLES = {
   dashboard: ['Overview', 'system-wide posture'],
   trust: ['Trust Center', 'authorization, live'],
+  scn: ['Significant Changes', 'change notifications'],
   vdr: ['VDR Security', 'vulnerability data'],
   transparency: ['Transparency Console', 'live evidence stream'],
   metrics: ['Pipeline Metrics', 'validation telemetry'],
@@ -430,6 +432,12 @@ const AppShell = () => {
               label="Trust Center"
               isActive={activeView === 'trust'}
               onClick={() => { navigate('trust'); setMobileMenuOpen(false); }}
+            />
+            <SidebarItem
+              icon={Megaphone}
+              label="Significant Changes"
+              isActive={activeView === 'scn'}
+              onClick={() => { navigate('scn'); setMobileMenuOpen(false); }}
             />
             <SidebarItem
               icon={Shield}
@@ -548,6 +556,12 @@ const AppShell = () => {
               label="Trust Center"
               isActive={activeView === 'trust'}
               onClick={() => navigate('trust')}
+            />
+            <SidebarItem
+              icon={Megaphone}
+              label="Significant Changes"
+              isActive={activeView === 'scn'}
+              onClick={() => navigate('scn')}
             />
             <SidebarItem
               icon={Shield}
@@ -674,6 +688,7 @@ const AppShell = () => {
           <div className="p-4 sm:p-6 lg:p-8 max-w-[1600px] mx-auto relative z-10">
             {activeView === 'dashboard' ? <DashboardContent onOpenRegister={goToRegister} /> :
               activeView === 'trust' ? <TrustCenterView /> :
+              activeView === 'scn' ? <ScnView /> :
               activeView === 'register' ? <RemediationRegister initialFilters={registerFilters} /> :
               !isAuthenticated ? (
                 <div className="flex items-center justify-center min-h-[60vh]">

--- a/src/components/modals/RegistrationModal.jsx
+++ b/src/components/modals/RegistrationModal.jsx
@@ -135,15 +135,15 @@ export const RegistrationModal = () => {
       variant="dark"
     >
       <div className="mb-6">
-        <div className="bg-gradient-to-br from-blue-900/30 to-blue-800/30 border border-blue-500/30 rounded-xl p-5 flex items-start gap-3 shadow-lg">
-          <div className="p-2 bg-blue-500/20 rounded-lg border border-blue-500/30 flex-shrink-0">
-            <Shield className="text-blue-400" size={20} />
+        <div className="bg-[#818cf8]/[0.06] border border-[#818cf8]/30 rounded-xl p-5 flex items-start gap-3">
+          <div className="p-2 bg-[#818cf8]/10 rounded-lg border border-[#818cf8]/30 flex-shrink-0">
+            <Shield className="text-[#818CF8]" size={20} />
           </div>
           <div className="text-sm">
-            <p className="text-white font-bold mb-2">
+            <p className="text-[10px] font-mono uppercase tracking-[0.14em] text-[#818CF8] mb-2">
               Federal Agency Personnel Only
             </p>
-            <p className="text-gray-300 leading-relaxed">
+            <p className="text-[#788596] leading-relaxed">
               Access to detailed technical validation findings and authorization package materials
               is restricted to authorized federal personnel with valid .gov or .mil email addresses.
             </p>
@@ -154,8 +154,8 @@ export const RegistrationModal = () => {
       <form onSubmit={handleSubmit} className="space-y-5">
         {/* Email */}
         <div>
-          <label htmlFor="email" className="block text-sm font-bold text-white mb-2">
-            <Mail size={14} className="inline mr-1 text-blue-400" />
+          <label htmlFor="email" className="flex items-center gap-1.5 text-[11px] font-mono uppercase tracking-[0.08em] text-[#788596] mb-2">
+            <Mail size={14} className="inline mr-1 text-[#818CF8]" />
             Official Email Address *
           </label>
           <input
@@ -165,23 +165,23 @@ export const RegistrationModal = () => {
             value={formData.email}
             onChange={handleChange}
             placeholder="e.g., john.smith@agency.gov"
-            className={`w-full px-4 py-3 bg-gray-900 border ${errors.email ? 'border-red-500/50' : 'border-gray-700'
-              } rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-white placeholder-gray-500 transition-all`}
+            className={`w-full px-4 py-3 bg-[#0A0E13] border ${errors.email ? 'border-[#F2607A]/60' : 'border-[#1A222D]'
+              } rounded-lg focus:ring-1 focus:ring-[#818cf8]/30 focus:border-[#818cf8]/60 text-[#E8EEF4] placeholder-[#424E5C] font-mono text-[13px] outline-none transition-all`}
             required
           />
           {errors.email && (
-            <p className="text-xs text-red-400 mt-2 flex items-center gap-1">
+            <p className="text-[11px] text-[#F2607A] mt-2 flex items-center gap-1 font-mono">
               <AlertCircle size={12} />
               {errors.email}
             </p>
           )}
-          <p className="text-xs text-gray-500 mt-1.5">Must be a .gov, .mil, or .fed.us email address</p>
+          <p className="text-[11px] text-[#424E5C] mt-1.5 font-mono">Must be a .gov, .mil, or .fed.us email address</p>
         </div>
 
         {/* Agency */}
         <div>
-          <label htmlFor="agency" className="block text-sm font-bold text-white mb-2">
-            <Shield size={14} className="inline mr-1 text-blue-400" />
+          <label htmlFor="agency" className="flex items-center gap-1.5 text-[11px] font-mono uppercase tracking-[0.08em] text-[#788596] mb-2">
+            <Shield size={14} className="inline mr-1 text-[#818CF8]" />
             Agency/Organization Name *
           </label>
           <input
@@ -191,12 +191,12 @@ export const RegistrationModal = () => {
             value={formData.agency}
             onChange={handleChange}
             placeholder="e.g., Department of Defense"
-            className={`w-full px-4 py-3 bg-gray-900 border ${errors.agency ? 'border-red-500/50' : 'border-gray-700'
-              } rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-white placeholder-gray-500 transition-all`}
+            className={`w-full px-4 py-3 bg-[#0A0E13] border ${errors.agency ? 'border-[#F2607A]/60' : 'border-[#1A222D]'
+              } rounded-lg focus:ring-1 focus:ring-[#818cf8]/30 focus:border-[#818cf8]/60 text-[#E8EEF4] placeholder-[#424E5C] font-mono text-[13px] outline-none transition-all`}
             required
           />
           {errors.agency && (
-            <p className="text-xs text-red-400 mt-2 flex items-center gap-1">
+            <p className="text-[11px] text-[#F2607A] mt-2 flex items-center gap-1 font-mono">
               <AlertCircle size={12} />
               {errors.agency}
             </p>
@@ -205,8 +205,8 @@ export const RegistrationModal = () => {
 
         {/* Contact Name */}
         <div>
-          <label htmlFor="contact" className="block text-sm font-bold text-white mb-2">
-            <User size={14} className="inline mr-1 text-blue-400" />
+          <label htmlFor="contact" className="flex items-center gap-1.5 text-[11px] font-mono uppercase tracking-[0.08em] text-[#788596] mb-2">
+            <User size={14} className="inline mr-1 text-[#818CF8]" />
             Contact Name *
           </label>
           <input
@@ -216,12 +216,12 @@ export const RegistrationModal = () => {
             value={formData.contact}
             onChange={handleChange}
             placeholder="e.g., John Smith"
-            className={`w-full px-4 py-3 bg-gray-900 border ${errors.contact ? 'border-red-500/50' : 'border-gray-700'
-              } rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-white placeholder-gray-500 transition-all`}
+            className={`w-full px-4 py-3 bg-[#0A0E13] border ${errors.contact ? 'border-[#F2607A]/60' : 'border-[#1A222D]'
+              } rounded-lg focus:ring-1 focus:ring-[#818cf8]/30 focus:border-[#818cf8]/60 text-[#E8EEF4] placeholder-[#424E5C] font-mono text-[13px] outline-none transition-all`}
             required
           />
           {errors.contact && (
-            <p className="text-xs text-red-400 mt-2 flex items-center gap-1">
+            <p className="text-[11px] text-[#F2607A] mt-2 flex items-center gap-1 font-mono">
               <AlertCircle size={12} />
               {errors.contact}
             </p>
@@ -230,8 +230,8 @@ export const RegistrationModal = () => {
 
         {/* System Name (Optional) */}
         <div>
-          <label htmlFor="system" className="block text-sm font-bold text-white mb-2">
-            <FileText size={14} className="inline mr-1 text-blue-400" />
+          <label htmlFor="system" className="flex items-center gap-1.5 text-[11px] font-mono uppercase tracking-[0.08em] text-[#788596] mb-2">
+            <FileText size={14} className="inline mr-1 text-[#818CF8]" />
             System/Project Name
           </label>
           <input
@@ -241,14 +241,14 @@ export const RegistrationModal = () => {
             value={formData.system}
             onChange={handleChange}
             placeholder="e.g., Agency Training Platform"
-            className="w-full px-4 py-3 bg-gray-900 border border-gray-700 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-white placeholder-gray-500 transition-all"
+            className="w-full px-4 py-3 bg-[#0A0E13] border border-[#1A222D] rounded-lg focus:ring-1 focus:ring-[#818cf8]/30 focus:border-[#818cf8]/60 text-[#E8EEF4] placeholder-[#424E5C] font-mono text-[13px] outline-none transition-all"
           />
-          <p className="text-xs text-gray-500 mt-1.5">Optional</p>
+          <p className="text-[11px] text-[#424E5C] mt-1.5 font-mono">Optional</p>
         </div>
 
         {/* Purpose (Optional) */}
         <div>
-          <label htmlFor="purpose" className="block text-sm font-bold text-white mb-2">
+          <label htmlFor="purpose" className="flex items-center gap-1.5 text-[11px] font-mono uppercase tracking-[0.08em] text-[#788596] mb-2">
             Access Purpose
           </label>
           <textarea
@@ -258,18 +258,18 @@ export const RegistrationModal = () => {
             onChange={handleChange}
             placeholder="e.g., Authorization review for new system deployment"
             rows={3}
-            className="w-full px-4 py-3 bg-gray-900 border border-gray-700 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-white placeholder-gray-500 resize-none transition-all"
+            className="w-full px-4 py-3 bg-[#0A0E13] border border-[#1A222D] rounded-lg focus:ring-1 focus:ring-[#818cf8]/30 focus:border-[#818cf8]/60 text-[#E8EEF4] placeholder-[#424E5C] font-mono text-[13px] resize-none outline-none transition-all"
           />
-          <p className="text-xs text-gray-500 mt-1.5">Optional</p>
+          <p className="text-[11px] text-[#424E5C] mt-1.5 font-mono">Optional</p>
         </div>
 
         {/* Submit Status */}
         {submitStatus && (
           <div className={`p-4 rounded-lg border ${submitStatus.type === 'success'
-              ? 'bg-green-500/10 border-green-500/30 text-green-400'
-              : 'bg-red-500/10 border-red-500/30 text-red-400'
+              ? 'bg-[#34E0C4]/10 border-[#34E0C4]/30 text-[#34E0C4]'
+              : 'bg-[#F2607A]/10 border-[#F2607A]/30 text-[#F2607A]'
             }`}>
-            <p className="font-medium">{submitStatus.message}</p>
+            <p className="font-mono text-[13px]">{submitStatus.message}</p>
           </div>
         )}
 
@@ -278,26 +278,26 @@ export const RegistrationModal = () => {
           <button
             type="submit"
             disabled={isSubmitting}
-            className="group relative flex-1 px-6 py-4 bg-gradient-to-r from-blue-600 to-blue-500 hover:from-blue-500 hover:to-blue-400 disabled:from-gray-700 disabled:to-gray-700 text-white rounded-xl font-bold transition-all shadow-lg shadow-blue-900/30 disabled:shadow-none disabled:cursor-not-allowed overflow-hidden"
+            className="group relative flex-1 px-6 py-4 bg-[#818CF8] hover:bg-[#9aa3fa] disabled:bg-[#1A222D] text-[#07090C] disabled:text-[#788596] rounded-xl font-mono text-[13px] font-semibold tracking-wide transition-all hover:shadow-[0_0_24px_-4px_#818CF8] disabled:shadow-none disabled:cursor-not-allowed overflow-hidden"
           >
-            <div className="absolute inset-0 bg-gradient-to-r from-white/0 via-white/10 to-white/0 translate-x-[-100%] group-hover:translate-x-[100%] transition-transform duration-1000"></div>
+            <div className="absolute inset-0 bg-gradient-to-r from-white/0 via-white/20 to-white/0 translate-x-[-100%] group-hover:translate-x-[100%] transition-transform duration-1000"></div>
             <span className="relative flex items-center justify-center gap-2">
-              <Shield size={18} />
-              {isSubmitting ? 'Submitting...' : 'Register for Access'}
+              <Shield size={16} />
+              {isSubmitting ? 'Submitting…' : 'Register for Access'}
             </span>
           </button>
           <button
             type="button"
             onClick={handleClose}
-            className="px-6 py-4 bg-gray-800 hover:bg-gray-700 text-gray-300 rounded-xl font-medium transition-colors border border-gray-700"
+            className="px-6 py-4 bg-transparent hover:border-[#788596] text-[#E8EEF4] rounded-xl font-mono text-[13px] transition-colors border border-[#1A222D]"
           >
             Cancel
           </button>
         </div>
       </form>
 
-      <div className="mt-6 pt-6 border-t border-gray-800">
-        <p className="text-xs text-gray-500 text-center leading-relaxed">
+      <div className="mt-6 pt-6 border-t border-[#1A222D]">
+        <p className="text-[11px] text-[#788596] text-center leading-relaxed font-mono">
           By registering, you acknowledge that access is restricted to federal personnel
           for official government use only.
         </p>

--- a/src/components/trust/ScnView.jsx
+++ b/src/components/trust/ScnView.jsx
@@ -1,0 +1,391 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Megaphone, GitBranch, Clock, ShieldCheck, AlertTriangle,
+  CheckCircle2, FileText, Send, History, Boxes
+} from 'lucide-react';
+
+// Data lives under the public `data/` tree (same base path the rest of the app uses).
+const DATA = import.meta.env.BASE_URL.endsWith('/')
+  ? `${import.meta.env.BASE_URL}data`
+  : `${import.meta.env.BASE_URL}/data`;
+
+const SCN_REPORT = `${DATA}/reports/samples/scn-sample-report.json`;
+const SCN_HISTORY = `${DATA}/scn_history.jsonl`;
+const SCN_HTML = `${DATA}/reports/html/scn-report.html`;
+const SCN_SCHEMA = `${DATA}/reports/schemas/scn-schema.json`;
+const OAR = `${DATA}/ongoing_authorization_report_Q4_2025.json`;
+
+// --- formatting helpers --------------------------------------------------
+const fmt = (ts) => {
+  if (!ts) return '—';
+  const d = new Date(ts);
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
+  });
+};
+const fmtDate = (ts) => {
+  if (!ts) return '—';
+  const d = new Date(ts);
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleDateString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric'
+  });
+};
+const titleize = (s) => (s || '').replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+// Change tier → console accent. routine = healthy/teal, adaptive = amber, transformative = red.
+const tierMeta = (tier) => {
+  const t = (tier || '').toLowerCase();
+  if (t.includes('transformative')) return { label: 'Transformative', tag: 'red', ck: 's' };
+  if (t.includes('adaptive')) return { label: 'Adaptive', tag: 'warn', ck: 's' };
+  return { label: 'Routine / Recurring', tag: 'ok', ck: 'p' };
+};
+const impactTag = (impact) => {
+  const i = (impact || '').toLowerCase();
+  if (i === 'positive') return 'ok';
+  if (i === 'negative' || i === 'degraded') return 'red';
+  return 'vi';
+};
+const riskTag = (level) => {
+  const l = (level || '').toLowerCase();
+  if (l === 'high') return 'red';
+  if (l === 'moderate' || l === 'medium') return 'warn';
+  return 'ok';
+};
+
+const Empty = ({ children }) => (
+  <div className="panel" style={{ padding: 40, textAlign: 'center' }}>
+    <Megaphone size={36} style={{ color: 'var(--faint)', margin: '0 auto 14px' }} />
+    <p style={{ color: 'var(--ash)', fontSize: 14 }}>{children}</p>
+  </div>
+);
+
+export const ScnView = () => {
+  const [scn, setScn] = useState(null);
+  const [history, setHistory] = useState([]);
+  const [snapshot, setSnapshot] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    const cb = Date.now();
+
+    const loadReport = fetch(`${SCN_REPORT}?t=${cb}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .catch(() => null);
+
+    const loadHistory = fetch(`${SCN_HISTORY}?t=${cb}`)
+      .then((r) => (r.ok ? r.text() : ''))
+      .then((txt) => txt.split('\n').map((l) => l.trim()).filter(Boolean)
+        .map((l) => { try { return JSON.parse(l); } catch { return null; } })
+        .filter(Boolean))
+      .catch(() => []);
+
+    const loadSnapshot = fetch(`${OAR}?t=${cb}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => d?.scn_snapshot || null)
+      .catch(() => null);
+
+    Promise.all([loadReport, loadHistory, loadSnapshot]).then(([rep, hist, snap]) => {
+      if (!alive) return;
+      setScn(rep);
+      setHistory(hist || []);
+      setSnapshot(snap);
+      setLoading(false);
+    });
+
+    return () => { alive = false; };
+  }, []);
+
+  const breakdown = snapshot?.breakdown || {};
+  const tier = tierMeta(scn?.change_classification?.tier);
+
+  const sortedHistory = useMemo(
+    () => [...history].sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp)),
+    [history]
+  );
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="kick">SIGNIFICANT CHANGE NOTIFICATION</div>
+        <h1 className="big">Significant changes, <span className="g">documented.</span></h1>
+        <Empty>Loading change notifications…</Empty>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="kick">
+        SCN PROGRAM · FEDRAMP 20x{scn?.report_type ? ` · ${scn.report_type.toUpperCase()} NOTIFICATION` : ''}
+      </div>
+      <h1 className="big">Significant changes, <span className="g">documented.</span></h1>
+      <p className="lede">
+        Every change to the authorization boundary is classified, verified, and notified under the
+        FedRAMP 20x Significant Change Notification process — published here for agency reviewers and
+        the 3PAO as it happens.
+      </p>
+
+      {/* ---- current period snapshot ---- */}
+      <h3 className="sec"><GitBranch size={13} /> Current authorization period</h3>
+      <div className="g4">
+        <div className="kpi">
+          <div className="v">{snapshot?.total_changes ?? 0}</div>
+          <div className="l">Total changes</div>
+        </div>
+        <div className="kpi">
+          <div className="v s">{breakdown.routine_recurring ?? 0}</div>
+          <div className="l">Routine</div>
+        </div>
+        <div className="kpi">
+          <div className="v a">{breakdown.adaptive ?? 0}</div>
+          <div className="l">Adaptive</div>
+        </div>
+        <div className="kpi">
+          <div className="v" style={{ color: (breakdown.transformative ?? 0) > 0 ? 'var(--red)' : 'var(--ink)' }}>
+            {breakdown.transformative ?? 0}
+          </div>
+          <div className="l">Transformative</div>
+          <div className="sub">{snapshot?.boundary_impact || snapshot?.terraform_changes ? 'boundary affected' : 'no boundary impact'}</div>
+        </div>
+      </div>
+
+      {!scn ? (
+        <Empty>No significant change notification has been published yet.</Empty>
+      ) : (
+        <>
+          {/* ---- latest notification ---- */}
+          <h3 className="sec"><Megaphone size={13} /> Latest notification</h3>
+          <div className="panel">
+            <div className="ph">
+              <h4 style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <span className="mono" style={{ color: 'var(--indigo)' }}>{scn.notification_id}</span>
+                <span className={`tag ${tier.tag}`}>{tier.label}</span>
+                {scn.change_classification?.is_emergency && <span className="tag red">EMERGENCY</span>}
+              </h4>
+              <span className={`tag ${riskTag(scn.security_impact_assessment?.overall_risk_level)}`}>
+                {titleize(scn.security_impact_assessment?.overall_risk_level || 'low')} risk
+              </span>
+            </div>
+            <div style={{ padding: 20 }}>
+              <div style={{ fontWeight: 600, fontSize: 17, marginBottom: 8 }}>
+                {scn.change_summary?.title}
+              </div>
+              <p style={{ color: 'var(--ash)', fontSize: 14, lineHeight: 1.6, marginBottom: 18 }}>
+                {scn.change_summary?.description}
+              </p>
+              <div className="g3">
+                <div>
+                  <div className="mono" style={{ fontSize: 10, color: 'var(--faint)', textTransform: 'uppercase', letterSpacing: '.06em' }}>Category</div>
+                  <div style={{ fontSize: 14, marginTop: 4 }}>{scn.change_classification?.category || '—'}</div>
+                </div>
+                <div>
+                  <div className="mono" style={{ fontSize: 10, color: 'var(--faint)', textTransform: 'uppercase', letterSpacing: '.06em' }}>Boundary impact</div>
+                  <div style={{ fontSize: 14, marginTop: 4 }}>{scn.change_summary?.boundary_impact ? 'Yes' : 'No'}</div>
+                </div>
+                <div>
+                  <div className="mono" style={{ fontSize: 10, color: 'var(--faint)', textTransform: 'uppercase', letterSpacing: '.06em' }}>Data impact</div>
+                  <div style={{ fontSize: 14, marginTop: 4 }}>{titleize(scn.security_impact_assessment?.data_impact || 'none')}</div>
+                </div>
+              </div>
+              {scn.change_classification?.evaluation_rationale && (
+                <p style={{ color: 'var(--faint)', fontSize: 12.5, lineHeight: 1.6, marginTop: 16, fontStyle: 'italic' }}>
+                  {scn.change_classification.evaluation_rationale}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* ---- affected components ---- */}
+          {scn.change_summary?.affected_components?.length > 0 && (
+            <div className="panel">
+              <div className="ph">
+                <h4><Boxes size={13} style={{ verticalAlign: -2, marginRight: 7 }} />Affected components</h4>
+                <span className="map">{scn.change_summary.affected_components.length} component{scn.change_summary.affected_components.length > 1 ? 's' : ''}</span>
+              </div>
+              {scn.change_summary.affected_components.map((c, i) => (
+                <div className="ctrl" key={i}>
+                  <div className="nm" style={{ flexWrap: 'wrap' }}>
+                    <span className="mono" style={{ color: 'var(--indigo)' }}>{c.component_id}</span>
+                    <span style={{ color: 'var(--ash)' }}>{c.description}</span>
+                  </div>
+                  <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
+                    <span className="tag vi">{titleize(c.component_type)}</span>
+                    <span className="tag warn">{titleize(c.change_type)}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* ---- timeline ---- */}
+          <div className="panel">
+            <div className="ph"><h4><Clock size={13} style={{ verticalAlign: -2, marginRight: 7 }} />Change timeline</h4></div>
+            {[
+              ['Change initiated', scn.timeline?.change_initiated],
+              ['Change completed', scn.timeline?.change_completed],
+              ['Verification completed', scn.timeline?.verification_completed],
+              ['Notification sent', scn.timeline?.notification_sent],
+              ['Notification deadline', scn.timeline?.notification_deadline, true],
+              ['Documentation deadline', scn.timeline?.documentation_deadline, true],
+            ].filter(([, v]) => v).map(([label, v, deadline]) => (
+              <div className="row" key={label}>
+                <span className="svc" style={{ width: 220, color: deadline ? 'var(--amber)' : 'var(--ink)' }}>{label}</span>
+                <span className="mono" style={{ marginLeft: 'auto', color: deadline ? 'var(--amber)' : 'var(--ash)' }}>{fmt(v)}</span>
+              </div>
+            ))}
+          </div>
+
+          {/* ---- security controls impact ---- */}
+          {scn.security_impact_assessment?.controls_affected?.length > 0 && (
+            <div className="panel">
+              <div className="ph">
+                <h4><ShieldCheck size={13} style={{ verticalAlign: -2, marginRight: 7 }} />Security controls impact</h4>
+                {scn.security_impact_assessment?.ksi_impact?.length > 0 && (
+                  <span className="map">{scn.security_impact_assessment.ksi_impact.join(' · ')}</span>
+                )}
+              </div>
+              {scn.security_impact_assessment.controls_affected.map((c, i) => (
+                <div className="ctrl" key={i}>
+                  <div className="nm" style={{ flexWrap: 'wrap' }}>
+                    <span className="mono" style={{ color: 'var(--indigo)' }}>{c.control_id}</span>
+                    <span>{c.control_name}</span>
+                    <span style={{ color: 'var(--ash)', fontSize: 12.5 }}>— {c.notes}</span>
+                  </div>
+                  <span className={`tag ${impactTag(c.impact)}`}>{titleize(c.impact)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* ---- controls verification ---- */}
+          {scn.controls_verification?.results?.length > 0 && (
+            <div className="panel">
+              <div className="ph">
+                <h4><CheckCircle2 size={13} style={{ verticalAlign: -2, marginRight: 7 }} />Controls verification</h4>
+                <span className={`tag ${scn.controls_verification.overall_status === 'pass' ? 'ok' : 'red'}`}>
+                  {(scn.controls_verification.overall_status || 'pass').toUpperCase()}
+                </span>
+              </div>
+              {scn.controls_verification.results.map((r, i) => (
+                <div className="ctrl" key={i}>
+                  <div className="nm" style={{ flexWrap: 'wrap' }}>
+                    <span className={`ck ${r.status === 'operational' ? 'p' : 's'}`}>
+                      {r.status === 'operational' ? '✓' : '!'}
+                    </span>
+                    <span className="mono" style={{ color: 'var(--indigo)' }}>{r.control_id}</span>
+                    <span>{r.control_name}</span>
+                    <span style={{ color: 'var(--ash)', fontSize: 12.5 }}>— {r.verification_detail}</span>
+                  </div>
+                  <span className="tag ok">{titleize(r.status)}</span>
+                </div>
+              ))}
+              <div className="row">
+                <span className="mono" style={{ fontSize: 11, color: 'var(--faint)' }}>
+                  {titleize(scn.controls_verification.verification_method)} · {scn.controls_verification.assessor} · {fmt(scn.controls_verification.verification_timestamp)}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* ---- notification recipients ---- */}
+          {scn.notification_recipients && (
+            <div className="panel">
+              <div className="ph"><h4><Send size={13} style={{ verticalAlign: -2, marginRight: 7 }} />Notification recipients</h4></div>
+              {[
+                ['FedRAMP PMO', scn.notification_recipients.fedramp_pmo],
+                [`3PAO${scn.notification_recipients.three_pao?.name ? ` · ${scn.notification_recipients.three_pao.name}` : ''}`, scn.notification_recipients.three_pao],
+                ...(scn.notification_recipients.agency_customers || []).map((a) => [`Agency · ${a.agency_id}`, a]),
+              ].filter(([, v]) => v).map(([label, v], i) => (
+                <div className="ctrl" key={i}>
+                  <div className="nm">
+                    <span className={`ck ${v.notified ? 'p' : 's'}`}>{v.notified ? '✓' : '○'}</span>
+                    <span>{label}</span>
+                    <span className="mono" style={{ color: 'var(--faint)', fontSize: 11 }}>{titleize(v.method)}</span>
+                  </div>
+                  <span className="mono" style={{ color: 'var(--ash)', fontSize: 11 }}>{v.notified ? fmt(v.notification_timestamp) : 'pending'}</span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* ---- audit trail ---- */}
+          {scn.audit_trail?.evaluation_activities?.length > 0 && (
+            <div className="panel">
+              <div className="ph">
+                <h4><History size={13} style={{ verticalAlign: -2, marginRight: 7 }} />Audit trail</h4>
+                <span className="map">{scn.audit_trail.record_id}</span>
+              </div>
+              {scn.audit_trail.evaluation_activities.map((a, i) => (
+                <div className="ctrl" key={i}>
+                  <div className="nm" style={{ flexWrap: 'wrap' }}>
+                    <span style={{ fontWeight: 500 }}>{a.activity}</span>
+                    <span className="mono" style={{ color: 'var(--faint)', fontSize: 11 }}>{a.actor}</span>
+                    <span style={{ color: 'var(--ash)', fontSize: 12.5 }}>— {a.outcome}</span>
+                  </div>
+                  <span className="mono" style={{ color: 'var(--ash)', fontSize: 11, flexShrink: 0 }}>{fmt(a.timestamp)}</span>
+                </div>
+              ))}
+              {scn.audit_trail.integrity_hash && (
+                <div className="row" style={{ gap: 18, flexWrap: 'wrap' }}>
+                  <span className="mono" style={{ fontSize: 10.5, color: 'var(--faint)' }}>
+                    SHA-256 · {scn.audit_trail.integrity_hash}
+                  </span>
+                  <span className="mono" style={{ fontSize: 10.5, color: 'var(--faint)', marginLeft: 'auto' }}>
+                    retained until {fmtDate(scn.audit_trail.retention_until)}
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* ---- change history ---- */}
+      <h3 className="sec"><History size={13} /> Change history</h3>
+      {sortedHistory.length === 0 ? (
+        <Empty>No change-detection events recorded yet.</Empty>
+      ) : (
+        <div className="panel">
+          {sortedHistory.map((h, i) => {
+            const t = tierMeta(h.classification);
+            return (
+              <div className="ctrl" key={i}>
+                <div className="nm" style={{ flexWrap: 'wrap' }}>
+                  <span className="mono" style={{ color: 'var(--indigo)' }}>{h.change_id}</span>
+                  <span>{h.description}</span>
+                  <span className="mono" style={{ color: 'var(--faint)', fontSize: 11 }}>{fmt(h.timestamp)}</span>
+                </div>
+                <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
+                  <span className={`tag ${t.tag}`}>{t.label}</span>
+                  {h.status && <span className="tag ok">{titleize(h.status)}</span>}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* ---- artifacts ---- */}
+      <h3 className="sec"><FileText size={13} /> Notification artifacts</h3>
+      <div className="dlg">
+        <a className="dl" href={SCN_HTML} target="_blank" rel="noopener noreferrer">
+          <div>
+            <div className="t">Full SCN report</div>
+            <div className="f">Rendered notification · HTML</div>
+          </div>
+          <span className="get">VIEW →</span>
+        </a>
+        <a className="dl" href={SCN_SCHEMA} target="_blank" rel="noopener noreferrer">
+          <div>
+            <div className="t">SCN schema</div>
+            <div className="f">Machine-readable structure · JSON</div>
+          </div>
+          <span className="get">OPEN →</span>
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default ScnView;


### PR DESCRIPTION
Keeps `master` in sync with the live site (deployed to `gh-pages` as `ce605e2e`).

## What changed
- **New public `ScnView`** — visualizes the Significant Change Notification program from existing JSON (`scn-sample-report.json`, `scn_history.jsonl`, OAR `scn_snapshot`): current-period change breakdown, latest notification (classification, affected components, timeline, controls impact, verification, recipients, audit trail), full change history, and links to the rendered SCN report + schema. Wired into both sidebars, the view registry, routing, and the render switch as a public view.
- **Register form re-skinned** to the console aesthetic — palette, mono labels, indigo inputs/CTA, ghost cancel — to match the new layout.

## Status
- ✅ `vite build` passes; SCN data artifacts bundle into `dist/data/`
- ✅ Already deployed to `gh-pages` (`ce605e2e`) and verified live
- ✅ Clean merge — only divergence is CI data-sync commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0153gdZpjnPFVukC1KxXz81n)_