### PR TITLE
Terminology: FedRAMP 20x Class C Moderate Certification

### DIFF
--- a/previews/whole-site-preview.html
+++ b/previews/whole-site-preview.html
@@ -175,7 +175,7 @@ const bars=(seed,n=48,warnHi=false)=>Array.from({length:n},(_,i)=>{const r=Math.
 const trend=[82,83.6,85.2,85.2,85.2,85.2,93.4,93.4,93.4,93.4,93.4,93.4,93.4,93.4];
 const trendBars=trend.map((v,i)=>`<i style="height:${((v-78)/(94-78))*82+18}%;background:var(--signal);animation-delay:${i*30}ms"></i>`).join('');
 
-const FW=[['FedRAMP 20x','AUTHORIZED'],['NIST 800-53 R5','MODERATE'],['FedRAMP KSI','MAPPED'],['CMMC 2.0 L2','CROSS-REF'],['CUI · DoDI 5200.48','ATTESTED'],['OMB A-130','ALIGNED']];
+const FW=[['FedRAMP 20x','CERTIFIED'],['NIST 800-53 R5','MODERATE'],['FedRAMP KSI','MAPPED'],['CMMC 2.0 L2','CROSS-REF'],['CUI · DoDI 5200.48','ATTESTED'],['OMB A-130','ALIGNED']];
 
 // ── views ──
 const V={};
@@ -183,7 +183,7 @@ const V={};
 V.dashboard=()=>`
   <div class="kick">LIVE · CONTINUOUSLY MONITORED · MODERATE IMPACT</div>
   <h1 class="big">Continuous validation, <span class="g">observed live.</span></h1>
-  <p class="lede">System-wide posture for the FedRAMP 20x Moderate authorization — Key Security Indicators validated continuously, with evidence sealed daily.</p>
+  <p class="lede">System-wide posture for the FedRAMP 20x Class C Moderate Certification — Key Security Indicators validated continuously, with evidence sealed daily.</p>
 
   <div class="panel" style="margin-bottom:14px">
     <div class="ph"><h4 style="display:flex;align-items:center;gap:10px"><span style="color:var(--signal)">◢ Operational</span> <span class="tag ok">MODERATE</span></h4><span class="map" style="cursor:pointer">↻ SYNC NOW</span></div>
@@ -212,7 +212,7 @@ V.dashboard=()=>`
     <div class="row"><span class="svc" style="width:130px">Compliance %</span><div class="spark" style="max-width:none;height:50px">${trendBars}</div><span class="mono" style="margin-left:14px;color:var(--signal)">82% → 93.4%</span></div></div>`;
 
 V.trust=()=>`
-  <div class="kick">02 — AUTHORIZATION RECORD</div>
+  <div class="kick">02 — CERTIFICATION RECORD</div>
   <h1 class="big">FedRAMP <span class="g">Trust Center</span></h1>
   <p class="lede">The public authorization record for Meridian LMS — posture, controls, and artifacts for agency reviewers.</p>
   <div class="console" style="margin-bottom:18px">
@@ -226,7 +226,7 @@ V.trust=()=>`
     <div class="log" id="log"></div>
   </div>
   <div class="marquee" style="margin-bottom:18px"><div class="mtrack">${[...FW,...FW].map(f=>`<span><b>${f[0]}</b> <span class="v">◆ ${f[1]}</span></span>`).join('')}</div></div>
-  <div class="bset">${FW.map(f=>`<span class="badge ${f[1]==='AUTHORIZED'?'s':''}">${f[1]==='AUTHORIZED'?'● ':''}${f[0]}</span>`).join('')}</div>
+  <div class="bset">${FW.map(f=>`<span class="badge ${f[1]==='CERTIFIED'?'s':''}">${f[1]==='CERTIFIED'?'● ':''}${f[0]}</span>`).join('')}</div>
   <div class="grid g4">
     <div class="kpi"><div class="v s">93.4%</div><div class="l">KSI compliance</div><div class="sub">57 / 61 passing</div></div>
     <div class="kpi"><div class="v">4</div><div class="l">Active gaps</div><div class="sub">in remediation</div></div>
@@ -323,8 +323,8 @@ V.schema=()=>`
 V.reports=()=>`
   <div class="kick">▣ — AUTHORIZATION ARTIFACTS</div>
   <h1 class="big">Reports &amp; <span class="g">evidence</span></h1>
-  <p class="lede">Machine-readable authorization data and audited artifacts. Public items stream openly; access-controlled items unlock for authorized reviewers.</p>
-  <div class="panel">${[['Ongoing Authorization Report (OAR)','Period ending 2026-05-15 · FRR-CCM','pub'],['Vulnerability Disclosure Report (VDR)','Release 25.09A · aggregate','pub'],['Significant Change Notifications','41 on record · FRR-SCN','pub'],['CSO Public Metadata','ADS-CSO-PUB · JSON','pub'],['3PAO Assessment Evidence','Independent assessor','nda'],['Authorization Package (OSCAL)','Full artifact bundle','nda']].map(d=>`<div class="lrow"><div><div class="t">${d[0]}</div><div class="d">${d[1]}</div></div><div class="meta">${d[2]==='nda'?'<span class="nda">ACCESS REQUIRED</span>':'<span class="pub">OPEN ACCESS</span>'}<span class="ar">→</span></div></div>`).join('')}</div>`;
+  <p class="lede">Machine-readable certification data and audited artifacts. Public items stream openly; access-controlled items unlock for authorized reviewers.</p>
+  <div class="panel">${[['Ongoing Authorization Report (OAR)','Period ending 2026-05-15 · FRR-CCM','pub'],['Vulnerability Disclosure Report (VDR)','Release 25.09A · aggregate','pub'],['Significant Change Notifications','41 on record · FRR-SCN','pub'],['CSO Public Metadata','ADS-CSO-PUB · JSON','pub'],['3PAO Assessment Evidence','Independent assessor','nda'],['Certification Package (OSCAL)','Full artifact bundle','nda']].map(d=>`<div class="lrow"><div><div class="t">${d[0]}</div><div class="d">${d[1]}</div></div><div class="meta">${d[2]==='nda'?'<span class="nda">ACCESS REQUIRED</span>':'<span class="pub">OPEN ACCESS</span>'}<span class="ar">→</span></div></div>`).join('')}</div>`;
 
 // render + nav
 const stage=document.getElementById('stage');

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -330,7 +330,7 @@ const KNOWN_VIEWS = new Set([
 
 const VIEW_TITLES = {
   dashboard: ['Overview', 'system-wide posture'],
-  trust: ['Trust Center', 'authorization, live'],
+  trust: ['Trust Center', 'certification, live'],
   scn: ['Significant Changes', 'change notifications'],
   vdr: ['VDR Security', 'vulnerability data'],
   transparency: ['Transparency Console', 'live evidence stream'],
@@ -340,7 +340,7 @@ const VIEW_TITLES = {
   mas: ['Assessment Scope', 'boundary & data flow'],
   policies: ['Policies', 'governance'],
   schema: ['Schema', 'machine-readable'],
-  reports: ['Reports', 'authorization artifacts'],
+  reports: ['Reports', 'certification artifacts'],
 };
 
 const AppShell = () => {
@@ -698,7 +698,7 @@ const AppShell = () => {
                     </div>
                     <h3 className="font-semibold text-white text-xl mb-3">Verified federal access required</h3>
                     <p className="text-sm text-gray-400 mb-4 leading-relaxed">
-                      This section contains detailed authorization data for the service. To keep that
+                      This section contains detailed certification data for the service. To keep that
                       data with verified government and DoD audiences, we ask you to register with your
                       <span className="text-gray-300"> .gov / .mil email</span> before viewing it — it
                       only takes a minute, and it's how we confirm you're a federal stakeholder.

--- a/src/components/modals/AccessRequiredModal.jsx
+++ b/src/components/modals/AccessRequiredModal.jsx
@@ -128,7 +128,7 @@ export const AccessRequiredModal = () => {
           {data?.featureName || 'This feature'} requires authentication
         </h2>
         <p style={s.subheading}>
-          Access to technical validation findings and authorization materials is restricted to
+          Access to technical validation findings and certification materials is restricted to
           authorized federal personnel.
         </p>
 

--- a/src/components/modals/RegistrationModal.jsx
+++ b/src/components/modals/RegistrationModal.jsx
@@ -144,7 +144,7 @@ export const RegistrationModal = () => {
               Federal Agency Personnel Only
             </p>
             <p className="text-[#788596] leading-relaxed">
-              Access to detailed technical validation findings and authorization package materials
+              Access to detailed technical validation findings and certification package materials
               is restricted to authorized federal personnel with valid .gov or .mil email addresses.
             </p>
           </div>

--- a/src/components/trust/PoliciesTab.jsx
+++ b/src/components/trust/PoliciesTab.jsx
@@ -199,7 +199,7 @@ export const PoliciesTab = memo(() => {
         <div className="kick">§ — GOVERNANCE</div>
         <h1 className="big">Governing <span className="g">standards</span></h1>
         <p className="lede">
-          The FedRAMP 20x rule families and policies governing this authorization, published openly.
+          The FedRAMP 20x rule families and policies governing this certification, published openly.
         </p>
       </div>
 

--- a/src/components/trust/ReportsTab.jsx
+++ b/src/components/trust/ReportsTab.jsx
@@ -284,10 +284,10 @@ export const ReportsTab = memo(() => {
   return (
     <div className="animate-in fade-in duration-500">
       {/* Header */}
-      <div className="kick">▣ — AUTHORIZATION ARTIFACTS</div>
+      <div className="kick">▣ — CERTIFICATION ARTIFACTS</div>
       <h1 className="big">Reports &amp; <span className="g">evidence</span></h1>
       <p className="lede">
-        Machine-readable authorization data and audited artifacts. Public items stream openly;
+        Machine-readable certification data and audited artifacts. Public items stream openly;
         access-controlled items unlock for authorized reviewers.
       </p>
 

--- a/src/components/trust/ThreePaoView.jsx
+++ b/src/components/trust/ThreePaoView.jsx
@@ -137,7 +137,7 @@ export const ThreePaoView = () => {
     if (!data?.report) return (
         <div className="min-h-screen bg-[#09090b] flex flex-col items-center justify-center text-slate-500 p-6">
             <div className="bg-rose-900/20 p-4 rounded-full mb-4 text-rose-500"><AlertTriangle size={48} /></div>
-            <h3 className="text-xl font-bold text-white mb-2">Authorization Package Unavailable</h3>
+            <h3 className="text-xl font-bold text-white mb-2">Certification Package Unavailable</h3>
             <p className="max-w-md text-center mb-6">The system could not retrieve the assessment artifacts.</p>
             <button onClick={() => window.location.reload()} className="px-4 py-2 bg-white/10 hover:bg-white/20 rounded-lg text-white transition-colors">Retry Connection</button>
         </div>

--- a/src/components/trust/TransparencyConsole.jsx
+++ b/src/components/trust/TransparencyConsole.jsx
@@ -628,7 +628,7 @@ const TransparencyConsole = () => {
                     </div>
                     <h1 className="big" style={{ fontSize: 26, marginBottom: 12 }}>Authentication Required</h1>
                     <p style={{ fontSize: 13, color: 'var(--ash)', marginBottom: 24, lineHeight: 1.55 }}>
-                        The System Transparency Console contains detailed technical validation findings and authorization materials restricted to authorized federal personnel.
+                        The System Transparency Console contains detailed technical validation findings and certification materials restricted to authorized federal personnel.
                     </p>
                     <div className="panel" style={{ background: 'var(--raise2)', padding: 16, marginBottom: 24, textAlign: 'left' }}>
                         <p className="mono" style={{ color: 'var(--ash)', marginBottom: 12, textAlign: 'center', textTransform: 'uppercase', letterSpacing: '.05em', fontSize: 10 }}>With Federal Access</p>

--- a/src/components/trust/TrustCenterView.jsx
+++ b/src/components/trust/TrustCenterView.jsx
@@ -20,7 +20,7 @@ const NAV = [
 const NAV_IDS = new Set(NAV.map(n => n[0]));
 
 const FRAMEWORKS = [
-    ['FedRAMP 20x', 'AUTHORIZED'], ['NIST 800-53 R5', 'MODERATE'], ['FedRAMP KSI', 'MAPPED'],
+    ['FedRAMP 20x', 'CERTIFIED'], ['NIST 800-53 R5', 'MODERATE'], ['FedRAMP KSI', 'MAPPED'],
     ['CMMC 2.0 L2', 'CROSS-REF'], ['CUI · DoDI 5200.48', 'ATTESTED'], ['OMB A-130', 'ALIGNED'],
 ];
 
@@ -132,7 +132,7 @@ export const TrustCenterView = () => {
     const blobDl = (blob, filename) => { const u = URL.createObjectURL(blob); const a = document.createElement('a'); a.href = u; a.download = filename; document.body.appendChild(a); a.click(); document.body.removeChild(a); URL.revokeObjectURL(u); };
     const viewConfig = async () => { if (!guard('View Secure Configuration')) return; try { const r = await fetch(`${API_CONFIG.BASE_URL}${API_CONFIG.ENDPOINTS.CONFIG_PUBLIC}`); openModal('markdown', { title: 'Secure Configuration', markdown: await r.text() }); } catch { alert('Load failed.'); } };
     const downloadConfig = async () => { if (!guard('Download Secure Configuration')) return; try { const r = await fetch(`${API_CONFIG.BASE_URL}${API_CONFIG.ENDPOINTS.CONFIG_PUBLIC}`); if (!r.ok) throw new Error(`HTTP ${r.status}`); blobDl(new Blob([await r.text()], { type: 'text/markdown' }), 'secure-configuration.md'); } catch (e) { alert(`Download failed: ${e.message}`); } };
-    const downloadPackage = async () => { if (!guard('Download Authorization Package')) return; try { const tok = localStorage.getItem(API_CONFIG.TOKEN_KEY); if (!tok) { alert('Session expired.'); return; } const r = await fetch(`${API_CONFIG.BASE_URL}${API_CONFIG.ENDPOINTS.PACKAGE_DOWNLOAD}`, { headers: { Authorization: `Bearer ${tok}` } }); if (!r.ok) throw new Error('Access Denied'); const j = await r.json(); if (j.url) window.location.href = j.url; } catch (e) { alert(`Download failed: ${e.message}`); } };
+    const downloadPackage = async () => { if (!guard('Download Certification Package')) return; try { const tok = localStorage.getItem(API_CONFIG.TOKEN_KEY); if (!tok) { alert('Session expired.'); return; } const r = await fetch(`${API_CONFIG.BASE_URL}${API_CONFIG.ENDPOINTS.PACKAGE_DOWNLOAD}`, { headers: { Authorization: `Bearer ${tok}` } }); if (!r.ok) throw new Error('Access Denied'); const j = await r.json(); if (j.url) window.location.href = j.url; } catch (e) { alert(`Download failed: ${e.message}`); } };
     const apiDocs = () => window.open('https://meridian-knowledge-solutions.github.io/fedramp-20x-public/documentation/api/', '_blank');
     const security = cso?.contacts?.security || 'security@meridianks.com';
 
@@ -170,11 +170,11 @@ export const TrustCenterView = () => {
                 {/* 01 OVERVIEW */}
                 <section id="overview" className="hero">
                     <div className="rv in">
-                        <Kick>LIVE · CONTINUOUSLY MONITORED · {cso?.package_id || 'AUTHORIZED'}</Kick>
-                        <h1>Authorization, observed in <span className="g">real time.</span></h1>
-                        <p className="sub">A living view of how {cso?.cso_name || 'Meridian LMS'} maintains its {cso?.authorization_type || 'FedRAMP 20x'} {cso?.impact_level || 'Moderate'} authorization — KSI posture, vulnerability data, and the controls beneath them, streaming as evidence is collected.</p>
+                        <Kick>LIVE · CONTINUOUSLY MONITORED · {cso?.package_id || 'CERTIFIED'}</Kick>
+                        <h1>Certification, observed in <span className="g">real time.</span></h1>
+                        <p className="sub">A living view of how {cso?.cso_name || 'Meridian LMS'} maintains its {cso?.authorization_type || 'FedRAMP 20x'} Class C {cso?.impact_level || 'Moderate'} Certification — KSI posture, vulnerability data, and the controls beneath them, streaming as evidence is collected.</p>
                         <div className="hbadges">
-                            <span className="badge s">● AUTHORIZED</span>
+                            <span className="badge s">● CERTIFIED</span>
                             <span className="badge i">{cso?.authorization_type || 'FedRAMP 20x'}</span>
                             <span className="badge">{cso?.impact_level || 'Moderate'} IMPACT</span>
                             <span className="badge">{cso?.service_model || 'SaaS'} · {cso?.cloud_provider || 'AWS'}</span>
@@ -275,15 +275,15 @@ export const TrustCenterView = () => {
 
                 {/* 05 ARTIFACTS (Documents, 20x language) */}
                 <section id="artifacts">
-                    <div className="rv"><Kick>05 — AUTHORIZATION ARTIFACTS</Kick><h2>Reports &amp; evidence</h2>
-                        <p className="lede">Machine-readable authorization data and audited artifacts. Public items stream openly; access-controlled items unlock for authorized agency reviewers.</p></div>
+                    <div className="rv"><Kick>05 — CERTIFICATION ARTIFACTS</Kick><h2>Reports &amp; evidence</h2>
+                        <p className="lede">Machine-readable certification data and audited artifacts. Public items stream openly; access-controlled items unlock for authorized agency reviewers.</p></div>
                     <div className="panel rv">
                         {[['Ongoing Authorization Report (OAR)', `Period ending ${oar?.reporting_period?.end_date || '2026-05-15'} · FRR-CCM`, 'pub', () => window.open(`${BASE_PATH}reports/samples/oar-report.json`, '_blank')],
                         ['Vulnerability Disclosure Report (VDR)', `${vdr?.metadata?.vdr_standard || 'Release 25.09A'} · aggregate`, 'pub', () => window.open(`${BASE_PATH}vdr_public_metrics.json`, '_blank')],
                         ['Significant Change Notifications (SCN)', `${oar?.data_sources?.scn_history_entries ?? 41} on record · FRR-SCN`, 'pub', () => jump('monitoring')],
                         ['CSO Public Metadata', 'ADS-CSO-PUB · machine-readable', 'pub', () => window.open(`${BASE_PATH}cso_public_info.json`, '_blank')],
                         ['3PAO Assessment Evidence', 'Independent assessor · access-controlled', 'nda', () => guard('3PAO Assessment')],
-                        ['Authorization Package (OSCAL)', 'Full artifact bundle · access-controlled', 'nda', downloadPackage]].map((d, i) => (
+                        ['Certification Package (OSCAL)', 'Full artifact bundle · access-controlled', 'nda', downloadPackage]].map((d, i) => (
                             <div className="lrow" key={i} onClick={d[3]}>
                                 <div><div className="t">{d[0]}</div><div className="d">{d[1]}</div></div>
                                 <div className="meta">{d[2] === 'nda' ? <span className="nda">ACCESS REQUIRED</span> : <span className="pub">OPEN ACCESS</span>}<span className="ar">→</span></div>
@@ -301,7 +301,7 @@ export const TrustCenterView = () => {
                 {/* 06 GOVERNANCE (Policies, 20x language) */}
                 <section id="governance">
                     <div className="rv"><Kick>06 — FedRAMP 20x RULE FAMILIES</Kick><h2>Governance</h2>
-                        <p className="lede">The standards and processes governing this authorization, published openly.</p></div>
+                        <p className="lede">The standards and processes governing this certification, published openly.</p></div>
                     <div className="panel rv">
                         {[['Continuous Monitoring', 'FRR-CCM-01 … 07'], ['Significant Change Notification', 'FRR-SCN'], ['Key Security Indicators', 'FRR-KSI'],
                         ['Minimum Assessment Scope', 'FRR-MAS'], ['Vulnerability Management', 'FRR-CVM'], ['Information Security Policy', 'NIST 800-53 PL'],
@@ -324,7 +324,7 @@ export const TrustCenterView = () => {
                     <div className="rv"><Kick>07 — MACHINE-READABLE</Kick><h2>Downloads</h2>
                         <p className="lede">Ready-to-share materials for your security and procurement teams.</p></div>
                     <div className="dlg rv">
-                        {[['Authorization Package', 'OSCAL · access-controlled', downloadPackage, isAuthenticated ? null : 'lock'],
+                        {[['Certification Package', 'OSCAL · access-controlled', downloadPackage, isAuthenticated ? null : 'lock'],
                         ['Secure Configuration Guide', 'Markdown · hardening', downloadConfig, null],
                         ['CRM Matrix (NIST/KSI/CMMC/CUI)', 'XLSX · 185 controls', () => window.open(`${BASE_PATH}Meridian_LMS_CRM_NIST_800-53_Rev5_CMMC_CUI.xlsx`, '_blank'), null],
                         ['CSO Public Metadata', 'JSON · ADS-CSO-PUB', () => window.open(`${BASE_PATH}cso_public_info.json`, '_blank'), null],
@@ -362,7 +362,7 @@ const Feedback = ({ security, entries }) => {
     return (
         <div className="grid2" style={{ padding: 20, gridTemplateColumns: '1fr 1fr', gap: 24 }}>
             <form onSubmit={submit} style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-                <textarea value={q} onChange={e => setQ(e.target.value)} rows={3} required placeholder="Ask about KSI validation, posture, or authorization data…"
+                <textarea value={q} onChange={e => setQ(e.target.value)} rows={3} required placeholder="Ask about KSI validation, posture, or certification data…"
                     style={{ background: '#0A0E13', border: '1px solid #1A222D', borderRadius: 9, padding: 12, color: '#E8EEF4', fontFamily: 'Geist Mono, monospace', fontSize: 12.5, resize: 'none', outline: 'none' }} />
                 <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="you@agency.gov (optional)"
                     style={{ background: '#0A0E13', border: '1px solid #1A222D', borderRadius: 9, padding: 12, color: '#E8EEF4', fontFamily: 'Geist Mono, monospace', fontSize: 12.5, outline: 'none' }} />

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -12,7 +12,7 @@ export const API_CONFIG = {
         CONFIG_PUBLIC: '/config',
         CONFIG_TENANT: '/config/tenant', // Requires Auth
 
-        // Authorization Package
+        // Certification Package
         // Returns JSON { url: "https://s3..." } signed URL
         PACKAGE_DOWNLOAD: '/package',
 


### PR DESCRIPTION
Replaces "authorization" branding language with "certification" per official FedRAMP rules, standardizing on **"FedRAMP 20x Class C Moderate Certification"**.

## Changed (branding text only)
- **Headline/status:** hero "Certification, observed in real time", "maintains its FedRAMP 20x **Class C** Moderate **Certification**", status badges `AUTHORIZED` → **`CERTIFIED`**, section kickers → "CERTIFICATION ARTIFACTS / RECORD", "certification data", "governing this **certification**".
- **Package renamed everywhere:** "Authorization Package" → **"Certification Package"** (download CTAs, OSCAL artifact label, unavailable state, modal copy, API comment).
- Static preview mock updated to match.

## Preserved (not touched)
- **FedRAMP terms of art:** "Authorization Boundary", Ongoing/Quarterly Authorization Report (OAR/QAR), KSI-AFR "Authorization by FedRAMP", Authorization Data Sharing (ADS), FRR-MAS rule text.
- **AWS's own FedRAMP authorization** (factual inheritance language).
- **Access language** ("authorized federal personnel/reviewers") and all **auth/login/HTTP `Authorization` headers / `isAuthorized` props / backend `'Authorized'` status / code identifiers**.

## Status
- ✅ `vite build` passes
- ✅ Deployed to `gh-pages` and verified (`index-CXXWgSZP.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0153gdZpjnPFVukC1KxXz81n)_