### PR TITLE
Track temporal_consistency_log.json (pipeline-consistency history live)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,11 +40,12 @@ public/data/*.jsonl
 !public/data/metrics_history.jsonl
 !public/data/validation_integrity_report.json
 !public/data/execution_quality_report.json
+# Append-only pipeline-consistency record (~10 MB and growing — that's its
+# purpose). Tracked in git (not LFS: the 15-min deploy checkout would burn LFS
+# bandwidth quota). Shallow CI checkout + gh-pages orphan keep it manageable.
+!public/data/temporal_consistency_log.json
 
 # --- Local-only / not-published compliance data (stays ignored) ---
-# NOTE: temporal_consistency_log.json (~10 MB, re-stamped every run) is held out
-# deliberately to avoid repo bloat — revisit via Git LFS if it must go live.
-public/data/temporal_consistency_log.json
 public/data/scn_history.jsonl
 public/data/3pao_audit_report.json
 public/data/ksi_logic.json


### PR DESCRIPTION
Tracks `temporal_consistency_log.json` so the Transparency Console's pipeline-consistency-over-time view goes live. The file is ~10 MB and append-only by design (that's the point — it's a long-term consistency record).

- Un-ignored like the other live data files. The governance bot already copies + `git add public/data/`-stages it, so **no pipeline change** is needed.
- **Not Git LFS, deliberately:** the 15-min deploy checkout would meter LFS bandwidth (~1 GB/mo free tier) and exhaust it almost immediately at 10 MB × ~96 pulls/day. Plain git is the cheaper fit — CI uses a shallow depth-1 checkout, and the gh-pages **orphan force-push keeps only one copy** on the deploy branch (no accumulation there).
- Only real growth is master history, which is inherent to an append-only log and delta-compresses well.

✅ `vite build` passes; the 10 MB file copies into `dist/data/`. Deploys automatically on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0153gdZpjnPFVukC1KxXz81n)_