### PR TITLE
Transparency: fix duplicated execution-quality issue text

### DIFF
--- a/src/components/trust/TransparencyConsole.jsx
+++ b/src/components/trust/TransparencyConsole.jsx
@@ -104,7 +104,6 @@ const isVerdictDisagreement = (issue) => {
 };
 
 const IssueCard = ({ issue, type }) => {
-    const [isExpanded, setIsExpanded] = useState(false);
     const parts = issue.split(': ');
     const ksiId = parts[0];
     const description = parts.slice(1).join(': ');
@@ -125,32 +124,14 @@ const IssueCard = ({ issue, type }) => {
     const label = typeLabels[type] || typeLabels.technical;
 
     return (
-        <div style={{ borderBottom: '1px solid var(--line)' }}>
-            <div
-                className="ctrl"
-                style={{ cursor: 'pointer', borderBottom: 'none' }}
-                onClick={() => setIsExpanded(!isExpanded)}
-            >
-                <div className="nm" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: 4 }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                        <span className="mono" style={{ color: 'var(--ink)', fontWeight: 600 }}>{ksiId}</span>
-                        <span className={`tag ${tag}`}>{label}</span>
-                    </div>
-                    <p style={{ fontSize: 13, color: 'var(--ash)', margin: 0 }}>{description}</p>
+        <div className="ctrl" style={{ borderBottom: '1px solid var(--line)' }}>
+            <div className="nm" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: 4, minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                    <span className="mono" style={{ color: 'var(--ink)', fontWeight: 600 }}>{ksiId}</span>
+                    <span className={`tag ${tag}`}>{label}</span>
                 </div>
-                <ChevronDown
-                    size={16}
-                    style={{
-                        color: 'var(--faint)', flexShrink: 0,
-                        transform: isExpanded ? 'rotate(180deg)' : 'none', transition: 'transform .15s'
-                    }}
-                />
+                <p style={{ fontSize: 13, color: 'var(--ash)', margin: 0, lineHeight: 1.5 }}>{description}</p>
             </div>
-            {isExpanded && (
-                <div className="code" style={{ borderTop: '1px solid var(--line)', whiteSpace: 'pre-wrap' }}>
-                    {description}
-                </div>
-            )}
         </div>
     );
 };


### PR DESCRIPTION
**What powers it:** the Execution Quality section reads **`public/data/execution_quality_report.json`** (loaded by `TransparencyConsole`). Two flat string arrays drive the three groups:
- `technical_issues[]` → partitioned by the view into **Technical Issues** (real `command failed …` / math-error entries) and **Score / Verdict Disagreements** (the `Assertion is False but score is N%` entries, matched by regex).
- `compliance_failures[]` → **Compliance Gaps**.

Each entry is `"KSI-XXX: message"`; the card splits on the first `: ` into the KSI id + description. Scores come from `execution_quality_score` / `compliance_health_score`.

**The duplicates were a render bug, not the data.** I verified the source arrays are unique (7 technical, 10 compliance, no dupes). `IssueCard` printed the description in the collapsed row *and* repeated the identical text in an expand panel — and since the collapsed row already showed it in full, expanding just doubled it. Simplified the card to render `id + tag + description` once.

✅ `vite build` passes. Auto-deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0153gdZpjnPFVukC1KxXz81n)_