### PR TITLE
Redesign Secure Configuration pop-out (console aesthetic)

### DIFF
--- a/previews/secure-config-modal-preview.html
+++ b/previews/secure-config-modal-preview.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Secure Configuration — redesigned pop-out</title>
+<style>
+  :root{
+    --base:#07090C; --raise:#0D1117; --raise2:#0A0E13; --line:#1A222D;
+    --ink:#E8EEF4; --ash:#788596; --faint:#424E5C; --signal:#34E0C4; --indigo:#818CF8;
+    --body:#C2CCD6; --mono:'Geist Mono',ui-monospace,'SFMono-Regular',Menlo,monospace;
+    --disp:'Geist','Inter',system-ui,sans-serif;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:#05070a;font-family:var(--disp);min-height:100vh;
+    display:flex;align-items:center;justify-content:center;padding:32px;
+    background-image:radial-gradient(ellipse at 50% -10%, #34E0C415, transparent 60%);}
+  /* modal shell */
+  .overlay{width:100%;max-width:900px}
+  .modal{background:var(--raise);border:1px solid var(--line);border-radius:16px;
+    overflow:hidden;box-shadow:0 40px 120px -30px #000;max-height:88vh;display:flex;flex-direction:column}
+  .head{display:flex;align-items:center;justify-content:space-between;padding:16px 22px;
+    background:#0b1016;border-bottom:1px solid var(--line)}
+  .head .ttl{display:flex;align-items:center;gap:10px;font-size:16px;font-weight:600;color:var(--ink)}
+  .head .ttl svg{color:var(--signal)}
+  .x{width:34px;height:34px;border-radius:9px;border:none;background:none;color:var(--ash);
+    cursor:pointer;display:flex;align-items:center;justify-content:center;transition:.15s}
+  .x:hover{background:var(--line);color:var(--ink)}
+  .body{padding:24px 26px;overflow-y:auto;color:var(--body);font-size:14px;line-height:1.7}
+  /* markdown elements */
+  .body h1{font-size:22px;font-weight:600;color:var(--ink);letter-spacing:-.02em;
+    margin:0 0 18px;padding-bottom:12px;border-bottom:1px solid var(--line)}
+  .body h2{font-size:17px;font-weight:600;color:var(--ink);margin:26px 0 12px;
+    padding-left:12px;border-left:2px solid var(--signal)}
+  .body h3{font-size:15px;font-weight:600;color:var(--ink);margin:20px 0 8px}
+  .body h4{font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.1em;
+    color:var(--ash);font-family:var(--mono);margin:16px 0 8px}
+  .body p{margin:0 0 16px;line-height:1.7}
+  .body ul{list-style:disc;padding-left:20px;margin:0 0 16px}
+  .body ul li::marker{color:var(--signal)}
+  .body ol{list-style:decimal;padding-left:20px;margin:0 0 16px}
+  .body ol li::marker{color:var(--indigo);font-family:var(--mono)}
+  .body li{margin-bottom:6px;line-height:1.6}
+  .body a{color:var(--indigo);text-decoration:underline;text-decoration-color:#818CF84d;text-underline-offset:2px}
+  .body code.inline{background:var(--raise2);color:var(--signal);padding:2px 6px;border-radius:5px;
+    border:1px solid var(--line);font-size:12.5px;font-family:var(--mono)}
+  .body pre{background:var(--base);border:1px solid var(--line);border-radius:12px;
+    padding:16px;overflow-x:auto;margin:0 0 16px}
+  .body pre code{color:#9FE9DC;font-size:12.5px;font-family:var(--mono);line-height:1.7;white-space:pre}
+  .body pre .k{color:var(--indigo)} .body pre .s{color:var(--signal)} .body pre .c{color:var(--faint)}
+  .tablewrap{overflow-x:auto;margin:0 0 20px;border:1px solid var(--line);border-radius:12px}
+  table{width:100%;border-collapse:collapse}
+  thead{background:#0b1016}
+  th{padding:10px 16px;text-align:left;font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;
+    color:var(--ash);font-family:var(--mono);font-weight:600}
+  td{padding:10px 16px;font-size:13px;color:var(--body);vertical-align:top}
+  tbody tr{border-bottom:1px solid var(--line);transition:.15s}
+  tbody tr:last-child{border-bottom:none}
+  tbody tr:hover{background:#34E0C408}
+  .tag{font-family:var(--mono);font-size:10px;padding:3px 8px;border-radius:6px;white-space:nowrap}
+  .tag.ok{color:var(--signal);background:#34E0C414} .tag.warn{color:#F2B85C;background:#F2B85C14}
+  blockquote{border-left:2px solid var(--indigo);background:#818CF810;padding:10px 14px;margin:0 0 16px;
+    border-radius:0 8px 8px 0;color:#B6C0CC;font-style:italic}
+  hr{border:none;border-top:1px solid var(--line);margin:24px 0}
+  .body strong{color:var(--ink);font-weight:600}
+  /* footer */
+  .foot{display:flex;align-items:center;justify-content:space-between;gap:16px;
+    padding:16px 26px;border-top:1px solid var(--line)}
+  .foot .sub{font-family:var(--mono);font-size:11px;color:var(--faint)}
+  .dl{display:inline-flex;align-items:center;gap:8px;background:var(--indigo);color:var(--base);
+    border:none;border-radius:9px;padding:10px 18px;font-family:var(--mono);font-size:12px;font-weight:600;
+    letter-spacing:.03em;cursor:pointer;transition:.15s}
+  .dl:hover{box-shadow:0 0 24px -4px var(--indigo)}
+  .note{max-width:900px;margin:0 auto 14px;font-family:var(--mono);font-size:11px;color:var(--ash);
+    letter-spacing:.04em;display:flex;align-items:center;gap:8px}
+  .note b{color:var(--signal)}
+</style>
+</head>
+<body>
+<div>
+  <div class="note"><b>PREVIEW</b> · redesigned “View Secure Configuration” pop-out (representative content)</div>
+  <div class="overlay">
+    <div class="modal">
+      <div class="head">
+        <div class="ttl">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+          Secure Configuration
+        </div>
+        <button class="x" aria-label="Close">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </button>
+      </div>
+
+      <div class="body">
+        <h1>Meridian LMS — Secure Configuration Baseline</h1>
+        <p>This baseline documents the hardened configuration enforced across the Meridian LMS
+        production boundary, validated continuously by the FedRAMP&nbsp;20x KSI pipeline. Settings
+        below are drawn from infrastructure-as-code and verified against live cloud state.</p>
+
+        <blockquote>All values are enforced via Terraform and re-validated every pipeline run;
+        drift triggers an automatic Significant Change evaluation.</blockquote>
+
+        <h2>Identity &amp; Access</h2>
+        <ul>
+          <li>Phishing-resistant <strong>MFA</strong> required org-wide (PIV/CAC + WebAuthn).</li>
+          <li>SSO via SAML 2.0; session timeout <code class="inline">15m</code> idle, <code class="inline">12h</code> absolute.</li>
+          <li>Least-privilege IAM permission sets, reviewed quarterly.</li>
+        </ul>
+
+        <h2>Encryption</h2>
+        <div class="tablewrap">
+          <table>
+            <thead><tr><th>Control</th><th>Setting</th><th>Scope</th><th>Status</th></tr></thead>
+            <tbody>
+              <tr><td>Data at rest</td><td>AES-256 (KMS CMK)</td><td>S3, RDS, EBS</td><td><span class="tag ok">ENFORCED</span></td></tr>
+              <tr><td>Data in transit</td><td>TLS 1.2+</td><td>All endpoints</td><td><span class="tag ok">ENFORCED</span></td></tr>
+              <tr><td>Key rotation</td><td>Annual (auto)</td><td>KMS</td><td><span class="tag ok">ENFORCED</span></td></tr>
+              <tr><td>Backup versioning</td><td>Enabled</td><td>State backend</td><td><span class="tag warn">REVIEW</span></td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h2>Logging &amp; Monitoring</h2>
+        <h4>CloudTrail policy excerpt</h4>
+        <pre><code><span class="c"># audit logging — all regions, log-file validation on</span>
+<span class="k">resource</span> <span class="s">"aws_cloudtrail" "audit"</span> {
+  is_multi_region_trail        = <span class="s">true</span>
+  enable_log_file_validation   = <span class="s">true</span>
+  kms_key_id                   = aws_kms_key.audit.arn
+}</code></pre>
+        <p>Logs stream to a centralized, immutable account with <strong>1-year</strong> retention
+        and anomaly detection via GuardDuty + Security Hub. See the
+        <a href="#">Transparency Console</a> for the live evidence stream.</p>
+
+        <hr/>
+        <h3>References</h3>
+        <ol>
+          <li>NIST SP 800-53 Rev 5 — SC-7, SC-13, SC-28, AU-2, IA-2(1)</li>
+          <li>FedRAMP 20x KSI — KSI-IAM, KSI-MLA, KSI-CNA</li>
+        </ol>
+      </div>
+
+      <div class="foot">
+        <div class="sub">FedRAMP 20x · machine-readable evidence</div>
+        <button class="dl">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+          Download Markdown
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/src/components/modals/BaseModal.jsx
+++ b/src/components/modals/BaseModal.jsx
@@ -32,12 +32,12 @@ export const BaseModal = ({ isOpen, onClose, title, children, size = 'default', 
       body: 'bg-white'
     },
     dark: {
-      container: 'bg-[#0f1014]',
-      header: 'border-gray-800/50 bg-gradient-to-r from-gray-900/90 to-gray-800/90',
-      title: 'text-white',
-      closeButton: 'hover:bg-gray-700/50',
-      closeIcon: 'text-gray-300',
-      body: 'bg-[#151618]'
+      container: 'bg-[#0D1117]',
+      header: 'border-[#1A222D] bg-[#0b1016]',
+      title: 'text-[#E8EEF4]',
+      closeButton: 'hover:bg-[#1A222D]',
+      closeIcon: 'text-[#788596]',
+      body: 'bg-[#0D1117]'
     }
   };
 

--- a/src/components/modals/MarkdownModal.jsx
+++ b/src/components/modals/MarkdownModal.jsx
@@ -37,92 +37,90 @@ export const MarkdownModal = () => {
       isOpen={isOpen}
       onClose={() => closeModal('markdown')}
       title={
-        <div className="flex items-center gap-2">
-          <FileText size={20} />
+        <div className="flex items-center gap-2.5">
+          <FileText size={18} className="text-[#34E0C4]" />
           <span>{data?.title || 'Document'}</span>
         </div>
       }
-      size="xlarge"
+      size="large"
       variant="dark"
     >
       {isLoading ? (
-        <div className="flex items-center justify-center py-12">
-          <Loader className="animate-spin text-blue-400" size={32} />
-          <span className="ml-3 text-gray-300">Loading document...</span>
+        <div className="flex items-center justify-center py-16">
+          <Loader className="animate-spin text-[#34E0C4]" size={28} />
+          <span className="ml-3 text-[#788596] font-mono text-sm">Loading document…</span>
         </div>
       ) : (
         <>
-          {/* Markdown Content with Professional Styling */}
-          <div className="markdown-content prose prose-invert prose-slate max-w-none mb-6">
+          {/* Markdown content — console-styled, constrained reading measure */}
+          <div className="markdown-content max-w-none mb-6 text-[14px] leading-[1.7] text-[#C2CCD6]">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
               rehypePlugins={[rehypeRaw, rehypeSanitize]}
               components={{
                 // Headings
-                h1: ({ node, ...props }) => <h1 className="text-3xl font-bold text-white mb-4 mt-8 pb-2 border-b border-gray-700" {...props} />,
-                h2: ({ node, ...props }) => <h2 className="text-2xl font-bold text-white mb-3 mt-6" {...props} />,
-                h3: ({ node, ...props }) => <h3 className="text-xl font-bold text-gray-100 mb-2 mt-4" {...props} />,
-                h4: ({ node, ...props }) => <h4 className="text-lg font-bold text-gray-100 mb-2 mt-3" {...props} />,
+                h1: ({ node, ...props }) => <h1 className="text-[22px] font-semibold text-[#E8EEF4] tracking-tight mb-5 mt-8 pb-3 border-b border-[#1A222D]" {...props} />,
+                h2: ({ node, ...props }) => <h2 className="text-[17px] font-semibold text-[#E8EEF4] mb-3 mt-7 pl-3 border-l-2 border-[#34E0C4]" {...props} />,
+                h3: ({ node, ...props }) => <h3 className="text-[15px] font-semibold text-[#E8EEF4] mb-2 mt-5" {...props} />,
+                h4: ({ node, ...props }) => <h4 className="text-[11px] font-semibold uppercase tracking-[0.1em] text-[#788596] mb-2 mt-4 font-mono" {...props} />,
 
                 // Paragraphs
-                p: ({ node, ...props }) => <p className="text-gray-300 mb-4 leading-relaxed" {...props} />,
+                p: ({ node, ...props }) => <p className="mb-4 leading-[1.7] text-[#C2CCD6]" {...props} />,
 
                 // Lists
-                ul: ({ node, ...props }) => <ul className="list-disc list-inside mb-4 space-y-2 text-gray-300" {...props} />,
-                ol: ({ node, ...props }) => <ol className="list-decimal list-inside mb-4 space-y-2 text-gray-300" {...props} />,
-                li: ({ node, ...props }) => <li className="ml-4 text-gray-300" {...props} />,
+                ul: ({ node, ...props }) => <ul className="list-disc list-outside pl-5 mb-4 space-y-1.5 text-[#C2CCD6] marker:text-[#34E0C4]" {...props} />,
+                ol: ({ node, ...props }) => <ol className="list-decimal list-outside pl-5 mb-4 space-y-1.5 text-[#C2CCD6] marker:text-[#818CF8] marker:font-mono" {...props} />,
+                li: ({ node, ...props }) => <li className="leading-[1.6] pl-1" {...props} />,
 
                 // Links
-                a: ({ node, ...props }) => <a className="text-blue-400 hover:text-blue-300 underline transition-colors" target="_blank" rel="noopener noreferrer" {...props} />,
+                a: ({ node, ...props }) => <a className="text-[#818CF8] hover:text-[#9aa3fa] underline decoration-[#818CF8]/30 underline-offset-2 transition-colors" target="_blank" rel="noopener noreferrer" {...props} />,
 
                 // Code
                 code: ({ node, inline, ...props }) =>
                   inline
-                    ? <code className="bg-gray-800 text-blue-300 px-1.5 py-0.5 rounded text-sm font-mono" {...props} />
-                    : <code className="block bg-gray-900 text-green-400 p-4 rounded-lg text-sm font-mono overflow-x-auto border border-gray-700" {...props} />,
-                pre: ({ node, ...props }) => <pre className="bg-gray-900 p-4 rounded-lg mb-4 overflow-x-auto border border-gray-700" {...props} />,
+                    ? <code className="bg-[#0A0E13] text-[#34E0C4] px-1.5 py-0.5 rounded border border-[#1A222D] text-[12.5px] font-mono" {...props} />
+                    : <code className="block text-[#9FE9DC] text-[12.5px] font-mono leading-[1.7]" {...props} />,
+                pre: ({ node, ...props }) => <pre className="bg-[#07090C] p-4 rounded-xl mb-4 overflow-x-auto border border-[#1A222D]" {...props} />,
 
                 // Tables
                 table: ({ node, ...props }) => (
-                  <div className="overflow-x-auto mb-4">
-                    <table className="min-w-full border-collapse border border-gray-700" {...props} />
+                  <div className="overflow-x-auto mb-5 rounded-xl border border-[#1A222D]">
+                    <table className="min-w-full border-collapse" {...props} />
                   </div>
                 ),
-                thead: ({ node, ...props }) => <thead className="bg-gray-800" {...props} />,
-                tbody: ({ node, ...props }) => <tbody className="divide-y divide-gray-700" {...props} />,
-                tr: ({ node, ...props }) => <tr className="border-b border-gray-700" {...props} />,
-                th: ({ node, ...props }) => <th className="px-4 py-2 text-left text-sm font-bold text-gray-100 border border-gray-700" {...props} />,
-                td: ({ node, ...props }) => <td className="px-4 py-2 text-sm text-gray-300 border border-gray-700" {...props} />,
+                thead: ({ node, ...props }) => <thead className="bg-[#0b1016]" {...props} />,
+                tbody: ({ node, ...props }) => <tbody {...props} />,
+                tr: ({ node, ...props }) => <tr className="border-b border-[#1A222D] last:border-0 hover:bg-[#34E0C4]/[0.03] transition-colors" {...props} />,
+                th: ({ node, ...props }) => <th className="px-4 py-2.5 text-left text-[10.5px] font-semibold uppercase tracking-[0.06em] text-[#788596] font-mono" {...props} />,
+                td: ({ node, ...props }) => <td className="px-4 py-2.5 text-[13px] text-[#C2CCD6] align-top" {...props} />,
 
                 // Blockquotes
                 blockquote: ({ node, ...props }) => (
-                  <blockquote className="border-l-4 border-blue-500 pl-4 py-2 my-4 bg-gray-800/50 italic text-gray-300" {...props} />
+                  <blockquote className="border-l-2 border-[#818CF8] bg-[#818CF8]/[0.06] pl-4 pr-3 py-2 my-4 rounded-r-lg text-[#B6C0CC] italic" {...props} />
                 ),
 
                 // Horizontal Rule
-                hr: ({ node, ...props }) => <hr className="border-gray-700 my-6" {...props} />,
+                hr: ({ node, ...props }) => <hr className="border-[#1A222D] my-6" {...props} />,
 
-                // Strong/Bold
-                strong: ({ node, ...props }) => <strong className="font-bold text-white" {...props} />,
-
-                // Emphasis/Italic
-                em: ({ node, ...props }) => <em className="italic text-gray-200" {...props} />,
+                // Strong / Emphasis
+                strong: ({ node, ...props }) => <strong className="font-semibold text-[#E8EEF4]" {...props} />,
+                em: ({ node, ...props }) => <em className="italic text-[#C2CCD6]" {...props} />,
               }}
             >
               {data?.markdown || ''}
             </ReactMarkdown>
           </div>
 
-          {/* Download Button */}
-          <div className="pt-6 border-t border-gray-700 flex justify-between items-center">
-            <p className="text-xs text-gray-500">
-              {data?.subtitle || 'FedRAMP 20x Documentation'}
+          {/* Footer */}
+          <div className="pt-5 border-t border-[#1A222D] flex justify-between items-center gap-4">
+            <p className="text-[11px] text-[#424E5C] font-mono">
+              {data?.subtitle || 'FedRAMP 20x · machine-readable evidence'}
             </p>
             <button
               onClick={handleDownload}
-              className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg transition-colors font-medium shadow-lg shadow-blue-900/20"
+              className="flex items-center gap-2 px-4 py-2.5 bg-[#818CF8] hover:bg-[#9aa3fa] text-[#07090C] rounded-lg transition-all font-mono text-[12px] font-semibold tracking-wide hover:shadow-[0_0_24px_-4px_#818CF8] whitespace-nowrap"
             >
-              <Download size={16} />
+              <Download size={15} />
               Download Markdown
             </button>
           </div>


### PR DESCRIPTION
Reskins the **"View Secure Configuration"** pop-out (the shared markdown modal) from the old blue/gray styling to the console aesthetic — the redesign missed it earlier.

- Console palette + readable typography: teal section accents (`h2` left-rule, list markers), indigo links, refined headings/eyebrows, comfortable body color + 1.7 line-height.
- **Console-styled tables** (muted mono header, hairline rows, subtle hover), **inset code blocks** (deepest base bg), tuned inline code, lists, and blockquotes.
- Narrowed to a comfortable reading measure (`large` vs `xlarge`).
- Indigo console CTA for Download; console-toned footer.
- Tuned the shared **dark `BaseModal` chrome** (header/body/border) to console tones — also tightens the registration modal.

Scope: the `markdown` modal is opened only by the Secure Configuration action, so this is contained.

Preview of the new look (representative content): `previews/secure-config-modal-preview.html`.

✅ `vite build` passes. Auto-deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0153gdZpjnPFVukC1KxXz81n)_