### PR TITLE
SCN impacted-KSI list on CR26 IDs; scn-schema pattern updated

### DIFF
--- a/public/data/reports/html/scn-report.html
+++ b/public/data/reports/html/scn-report.html
@@ -66,7 +66,7 @@
                     </div>
                 </div>
                 <div class="flex flex-wrap gap-2 lg:justify-end">
-                    <span class="pill pill-info"><span class="opacity-60">Generated</span><span class="font-mono">2026-07-07 01:25 UTC</span></span>
+                    <span class="pill pill-info"><span class="opacity-60">Generated</span><span class="font-mono">2026-07-07 04:56 UTC</span></span>
                     <span class="pill pill-info"><span class="opacity-60">Data</span><span class="font-mono">LIVE</span></span>
                 </div>
             </div>

--- a/public/data/reports/schemas/scn-schema.json
+++ b/public/data/reports/schemas/scn-schema.json
@@ -204,7 +204,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^KSI-[A-Z]{3}-\\d{2}$"
+            "pattern": "^KSI-[A-Z]{2,4}-[A-Z]{3}$"
           },
           "description": "Key Security Indicators affected by this change"
         },

--- a/public/trust-center/reports/html/scn-report.html
+++ b/public/trust-center/reports/html/scn-report.html
@@ -66,7 +66,7 @@
                     </div>
                 </div>
                 <div class="flex flex-wrap gap-2 lg:justify-end">
-                    <span class="pill pill-info"><span class="opacity-60">Generated</span><span class="font-mono">2026-07-07 01:25 UTC</span></span>
+                    <span class="pill pill-info"><span class="opacity-60">Generated</span><span class="font-mono">2026-07-07 04:56 UTC</span></span>
                     <span class="pill pill-info"><span class="opacity-60">Data</span><span class="font-mono">LIVE</span></span>
                 </div>
             </div>

--- a/public/trust-center/reports/json/scn-report.json
+++ b/public/trust-center/reports/json/scn-report.json
@@ -80,10 +80,9 @@
       }
     ],
     "ksi_impact": [
-      "KSI-CMT-01",
-      "KSI-CMT-02",
-      "KSI-CMT-05",
-      "KSI-AFR-05"
+      "KSI-CMT-LMC",
+      "KSI-CMT-RMV",
+      "KSI-CMT-VTD"
     ],
     "data_impact": "none"
   },
@@ -190,7 +189,7 @@
       }
     ],
     "retention_until": "2027-06-24",
-    "integrity_hash": "1f305fc096fec1ecf2bc69c2bc1e57378ba4934c1e7a62088fe5bac2add0d85b"
+    "integrity_hash": "fb6d723b06c1e225dcd9cb37a530b546aec478563145031f7afaec3608fa142c"
   },
   "attachments": [
     {

--- a/public/trust-center/schemas/scn-schema.json
+++ b/public/trust-center/schemas/scn-schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://meridianks.com/fedramp/schemas/scn-v1.0.json",
   "title": "FedRAMP 20x Significant Change Notification (SCN)",
-  "description": "Machine-readable schema for Significant Change Notifications per FRR-SCN requirements. Covers all four change tiers: Routine Recurring, Adaptive, Transformative, and Certification Class Change.",
+  "description": "Machine-readable schema for Significant Change Notifications per CR26 FRR-SCN requirements. Covers the CR26 change types: Routine Recurring, Adaptive, Transformative, and Certification Class Change.",
   "type": "object",
   "required": [
     "schema_version",
@@ -204,7 +204,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^KSI-[A-Z]{3}-\\d{2}$"
+            "pattern": "^KSI-[A-Z]{2,4}-[A-Z]{3}$"
           },
           "description": "Key Security Indicators affected by this change"
         },

--- a/reports/generate_public_reports.py
+++ b/reports/generate_public_reports.py
@@ -181,11 +181,15 @@ class PublicReportGenerator:
 
     # KSI families most directly exercised by change-management events.
     # Mapped from change-tier so the SCN can publish which KSIs were re-validated.
+    # CR26 mnemonic indicators (KSI-CMT family; incident-response for the
+    # critical fast-path). Legacy KSI-CMT-05 was retired pre-CR26 (superseded
+    # by the FRR-SCN rules themselves) and KSI-AFR-05 was promoted to FRR-SCN,
+    # so neither appears here — the SCN itself evidences FRR-SCN compliance.
     KSI_IMPACT_BY_TIER = {
-        "transformative": ["KSI-CMT-01", "KSI-CMT-02", "KSI-CMT-03", "KSI-CMT-04", "KSI-CMT-05", "KSI-AFR-05"],
-        "adaptive": ["KSI-CMT-01", "KSI-CMT-02", "KSI-CMT-05", "KSI-AFR-05"],
-        "routine_recurring": ["KSI-CMT-01"],
-        "critical": ["KSI-CMT-01", "KSI-CMT-02", "KSI-CMT-05", "KSI-IRP-01"],
+        "transformative": ["KSI-CMT-LMC", "KSI-CMT-RMV", "KSI-CMT-VTD", "KSI-CMT-RVP"],
+        "adaptive": ["KSI-CMT-LMC", "KSI-CMT-RMV", "KSI-CMT-VTD"],
+        "routine_recurring": ["KSI-CMT-LMC"],
+        "critical": ["KSI-CMT-LMC", "KSI-CMT-RMV", "KSI-INR-RIR"],
     }
 
     CONTROL_NAMES = {
@@ -446,7 +450,7 @@ class PublicReportGenerator:
                 ),
             })
 
-        ksi_impact = self.KSI_IMPACT_BY_TIER.get(tier, ["KSI-CMT-01"])
+        ksi_impact = self.KSI_IMPACT_BY_TIER.get(tier, ["KSI-CMT-LMC"])
 
         verification_results = []
         for cid in sorted(control_ids):
@@ -572,7 +576,7 @@ class PublicReportGenerator:
                     "impact": "positive",
                     "notes": "Enhanced WAF rules improve boundary protection",
                 }],
-                "ksi_impact": ["KSI-CNA-04"],
+                "ksi_impact": ["KSI-CNA-DFP"],
                 "data_impact": "none",
             },
             "controls_verification": {


### PR DESCRIPTION
Companion to the backend fix: the SCN section's security impact assessment listed **legacy numeric KSI IDs** (including retired `KSI-CMT-05` and promoted `KSI-AFR-05`) where CR26 `SCN-CSO-INF` requires identifying impacted Key Security Indicators. The **NIST 800-53 control references are retained deliberately** — CR26 keeps 800-53 mappings (per-KSI `controls`, CTL section) and they're valid supplementary context.

- Served `scn-report.json` + HTML republished with CR26 KSI impact (`KSI-CMT-LMC/RMV/VTD` for the live adaptive notification); validates cleanly against the updated schema
- `scn-schema.json` `ksi_impact` pattern → mnemonic IDs (both published copies)
- Generator copy synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkTLgdbHAQYrbYMyQmKmPo

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkTLgdbHAQYrbYMyQmKmPo)_