### PR TITLE
Make trust center tenant-configurable via Vite env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Trust Center tenant configuration (Vite build-time env vars).
+# Copy to .env.production (or let the pipeline repo's
+# portable-core/deploy/render.py --trust-center-env generate it from
+# environment.yaml). Unset vars fall back to the Meridian production values in
+# src/config/tenant.js, so an empty file reproduces the current site.
+
+# Organization identity
+VITE_ORG_NAME="Example Org, Inc."
+
+# Backend API Gateway endpoint (your tenant's CloudFormation output)
+VITE_API_URL="https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod"
+
+# GitHub raw-data source: this fork, where the pipeline syncs public data
+VITE_REPO_OWNER="example-org"
+VITE_REPO_NAME="fedramp-trust-center"
+VITE_BRANCH="master"
+
+# Contacts (fallbacks when public/data/cso_public_info.json lacks them)
+VITE_SECURITY_EMAIL="security@example.gov"
+VITE_FEDRAMP_EMAIL="fedramp@example.gov"
+VITE_PRIVACY_EMAIL="privacy@example.gov"
+
+# External links
+VITE_API_DOCS_URL="https://example-org.github.io/fedramp-20x-public/documentation/api/"
+VITE_QUARTERLY_REGISTRATION_URL=""

--- a/src/components/modals/RegistrationModal.jsx
+++ b/src/components/modals/RegistrationModal.jsx
@@ -3,6 +3,7 @@ import { useModal } from '../../contexts/ModalContext';
 import { useAuth } from '../../hooks/useAuth';
 import { BaseModal } from './BaseModal';
 import { Shield, Mail, User, FileText, AlertCircle } from 'lucide-react';
+import { TENANT } from '../../config/tenant';
 
 export const RegistrationModal = () => {
   const { modals, closeModal } = useModal();
@@ -61,9 +62,8 @@ export const RegistrationModal = () => {
     try {
       // --- START REAL API INTEGRATION ---
       
-      // 1. Get API Endpoint (Ensure VITE_API_URL is set in your .env file)
-      // Fallback is provided but should be replaced with your real API Gateway URL
-      const API_URL = import.meta.env.VITE_API_URL || 'https://7d7pdwb9t3.execute-api.us-east-1.amazonaws.com/prod';
+      // 1. Get API Endpoint (tenant-configured; see src/config/tenant.js)
+      const API_URL = TENANT.API_URL;
 
       // 2. Prepare payload to match Backend expectations
       const payload = {

--- a/src/components/modals/SettingsModal.jsx
+++ b/src/components/modals/SettingsModal.jsx
@@ -2,6 +2,7 @@
 import React, { useCallback, memo } from 'react';
 import { Database, XCircle, LogOut, Trash2 } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
+import { TENANT } from '../../config/tenant';
 
 const THEME = {
     panel: 'bg-[#121217]',
@@ -18,7 +19,7 @@ const SettingsModal = memo(({ isOpen, onClose }) => {
     const handleDataDeletion = useCallback(() => {
         const subject = encodeURIComponent('Data Deletion Request - Trust Center');
         const body = encodeURIComponent(
-            `I am requesting deletion of my data from the Meridian Trust Center.\n\n` +
+            `I am requesting deletion of my data from the ${TENANT.ORG_NAME} Trust Center.\n\n` +
             `Agency: ${user?.agency || 'N/A'}\n` +
             `Email: ${user?.email || 'N/A'}\n\n` +
             `Please delete:\n` +
@@ -27,7 +28,7 @@ const SettingsModal = memo(({ isOpen, onClose }) => {
             `- Any other stored personal data\n\n` +
             `Thank you.`
         );
-        window.location.href = `mailto:fedramp-security@meridianks.com?subject=${subject}&body=${body}`;
+        window.location.href = `mailto:${TENANT.PRIVACY_EMAIL}?subject=${subject}&body=${body}`;
     }, [user]);
 
     if (!isOpen) return null;

--- a/src/components/trust/TrustCenterView.jsx
+++ b/src/components/trust/TrustCenterView.jsx
@@ -4,6 +4,7 @@ import { useModal } from '../../contexts/ModalContext';
 import { useSystemStatus } from '../../hooks/useSystemStatus';
 import { useData } from '../../hooks/useData';
 import { API_CONFIG, QUARTERLY_REGISTRATION_URL } from '../../config/api';
+import { TENANT } from '../../config/tenant';
 import { BASE_PATH } from '../../config/theme';
 import { getRouteSegments, setRoute, onRouteChange } from '../../utils/hashRoute';
 import { Download, ExternalLink, Lock, ArrowRight, Video, FileJson, Send } from 'lucide-react';
@@ -136,8 +137,8 @@ export const TrustCenterView = () => {
     const viewConfig = async () => { if (!guard('View Secure Configuration')) return; try { const r = await fetch(`${API_CONFIG.BASE_URL}${API_CONFIG.ENDPOINTS.CONFIG_PUBLIC}`); openModal('markdown', { title: 'Secure Configuration', markdown: await r.text() }); } catch { alert('Load failed.'); } };
     const downloadConfig = async () => { if (!guard('Download Secure Configuration')) return; try { const r = await fetch(`${API_CONFIG.BASE_URL}${API_CONFIG.ENDPOINTS.CONFIG_PUBLIC}`); if (!r.ok) throw new Error(`HTTP ${r.status}`); blobDl(new Blob([await r.text()], { type: 'text/markdown' }), 'secure-configuration.md'); } catch (e) { alert(`Download failed: ${e.message}`); } };
     const downloadPackage = async () => { if (!guard('Download Certification Package')) return; try { const tok = localStorage.getItem(API_CONFIG.TOKEN_KEY); if (!tok) { alert('Session expired.'); return; } const r = await fetch(`${API_CONFIG.BASE_URL}${API_CONFIG.ENDPOINTS.PACKAGE_DOWNLOAD}`, { headers: { Authorization: `Bearer ${tok}` } }); if (!r.ok) throw new Error('Access Denied'); const j = await r.json(); if (j.url) window.location.href = j.url; } catch (e) { alert(`Download failed: ${e.message}`); } };
-    const apiDocs = () => window.open('https://meridian-knowledge-solutions.github.io/fedramp-20x-public/documentation/api/', '_blank');
-    const security = cso?.contacts?.security || 'security@meridianks.com';
+    const apiDocs = () => window.open(TENANT.API_DOCS_URL, '_blank');
+    const security = cso?.contacts?.security || TENANT.SECURITY_EMAIL;
 
     if (loading) {
         return (
@@ -318,7 +319,7 @@ export const TrustCenterView = () => {
                     {/* feedback */}
                     <div className="panel rv" style={{ marginTop: 14 }}>
                         <div className="grp-h"><h4>Feedback &amp; questions</h4><span className="map">FRR-CCM (OCR + Quarterly Review)</span></div>
-                        <Feedback security={cso?.contacts?.fedramp || 'fedramp_20x@meridianks.com'} entries={feedback} />
+                        <Feedback security={cso?.contacts?.fedramp || TENANT.FEDRAMP_EMAIL} entries={feedback} />
                     </div>
                 </section>
 

--- a/src/components/trust/VDRPublicMetricsDashboard.tsx
+++ b/src/components/trust/VDRPublicMetricsDashboard.tsx
@@ -5,6 +5,7 @@ import {
 } from "recharts";
 
 import { BASE_PATH } from '../../config/theme';
+import { TENANT } from '../../config/tenant';
 
 // Console palette
 const SIGNAL = "#34E0C4";  // teal — live / healthy / pass
@@ -842,7 +843,7 @@ export default function VDRDashboard() {
          ────────────────────────────────────────────── */}
       <div className="cta">
         <h3>Found a vulnerability? Report it through coordinated disclosure.</h3>
-        <button className="btn" onClick={() => window.location.href = "mailto:security@meridianks.com?subject=Vulnerability%20Disclosure"}>Submit a report →</button>
+        <button className="btn" onClick={() => window.location.href = `mailto:${TENANT.SECURITY_EMAIL}?subject=Vulnerability%20Disclosure`}>Submit a report →</button>
       </div>
 
       {/* Footer */}

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -1,7 +1,10 @@
 // === AWS API GATEWAY CONFIGURATION ===
+// Tenant-specific values come from src/config/tenant.js (env-var driven).
+import { TENANT } from './tenant';
+
 export const API_CONFIG = {
-    // The core API Gateway endpoint from CloudFormation
-    BASE_URL: 'https://7d7pdwb9t3.execute-api.us-east-1.amazonaws.com/prod',
+    // The core API Gateway endpoint from CloudFormation (per-tenant)
+    BASE_URL: TENANT.API_URL,
 
     // API endpoints mapped from legacy SPA
     ENDPOINTS: {
@@ -39,14 +42,13 @@ export const API_CONFIG = {
 // === QUARTERLY REVIEW SESSION ===
 // Canonical registration URL maintained here so pipeline data syncs cannot overwrite it.
 // Update this value whenever a new Teams event is created for the next quarterly session.
-export const QUARTERLY_REGISTRATION_URL =
-    'https://events.teams.microsoft.com/event/7f521f38-4991-4772-8c5d-4d96f215c60c@bc633bf7-1766-4960-bc95-a16fdb861a57';
+export const QUARTERLY_REGISTRATION_URL = TENANT.QUARTERLY_REGISTRATION_URL;
 
 // === GITHUB RAW DATA CONFIGURATION ===
 // Used for fetching static assets directly from the repo
-const REPO_OWNER = 'Meridian-Knowledge-Solutions';
-const REPO_NAME = 'fedramp-trust-center'; // UPDATED: Points to the new repo
-const BRANCH = 'master';
+const REPO_OWNER = TENANT.REPO_OWNER;
+const REPO_NAME = TENANT.REPO_NAME;
+const BRANCH = TENANT.BRANCH;
 
 export const GITHUB_BASE_URL = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${BRANCH}`;
 

--- a/src/config/tenant.js
+++ b/src/config/tenant.js
@@ -1,0 +1,38 @@
+// === TENANT CONFIGURATION ===
+// Every environment-specific value the trust center needs, in one place,
+// overridable at build time via Vite env vars (see .env.example). The defaults
+// are the Meridian production values, so a build with no .env behaves exactly
+// as before. A retargeted deployment generates .env.production from its
+// environment.yaml manifest (portable-core/deploy/render.py in the pipeline repo).
+//
+// NOTE: each value must use the FULL `import.meta.env.VITE_*` expression —
+// Vite's build-time replacement is textual and does not see aliased access
+// (e.g. `const env = import.meta.env; env.VITE_X` is NOT replaced).
+
+export const TENANT = {
+  // Organization identity
+  ORG_NAME: import.meta.env.VITE_ORG_NAME || 'Meridian Knowledge Solutions',
+
+  // Backend API Gateway (CloudFormation output for this tenant's stack)
+  API_URL: import.meta.env.VITE_API_URL || 'https://7d7pdwb9t3.execute-api.us-east-1.amazonaws.com/prod',
+
+  // GitHub raw-data source (this repo, where the pipeline syncs public data)
+  REPO_OWNER: import.meta.env.VITE_REPO_OWNER || 'Meridian-Knowledge-Solutions',
+  REPO_NAME: import.meta.env.VITE_REPO_NAME || 'fedramp-trust-center',
+  BRANCH: import.meta.env.VITE_BRANCH || 'master',
+
+  // Contact addresses (fallbacks when cso_public_info.json lacks them)
+  SECURITY_EMAIL: import.meta.env.VITE_SECURITY_EMAIL || 'security@meridianks.com',
+  FEDRAMP_EMAIL: import.meta.env.VITE_FEDRAMP_EMAIL || 'fedramp_20x@meridianks.com',
+  PRIVACY_EMAIL: import.meta.env.VITE_PRIVACY_EMAIL || 'fedramp-security@meridianks.com',
+
+  // External documentation link ("API Docs" button)
+  API_DOCS_URL: import.meta.env.VITE_API_DOCS_URL
+    || 'https://meridian-knowledge-solutions.github.io/fedramp-20x-public/documentation/api/',
+
+  // Quarterly review registration (Teams event; rotates per quarter)
+  QUARTERLY_REGISTRATION_URL: import.meta.env.VITE_QUARTERLY_REGISTRATION_URL
+    || 'https://events.teams.microsoft.com/event/7f521f38-4991-4772-8c5d-4d96f215c60c@bc633bf7-1766-4960-bc95-a16fdb861a57',
+};
+
+export default TENANT;


### PR DESCRIPTION
## Summary

Centralizes every environment-specific value into a new `src/config/tenant.js`, driven by `VITE_*` env vars with the current Meridian production values as defaults — **a build with no `.env` is behavior-identical to today's site**, so merging does not change the deployed trust center.

- `src/config/tenant.js` — org name, API Gateway URL, repo owner/name/branch, security/fedramp/privacy contacts, API-docs link, quarterly-registration URL. Uses full `import.meta.env.VITE_*` expressions (Vite's static replacement does not see aliased access).
- `src/config/api.js` — `BASE_URL`, `REPO_OWNER/NAME/BRANCH`, `QUARTERLY_REGISTRATION_URL` now sourced from `TENANT`.
- `SettingsModal`, `TrustCenterView`, `VDRPublicMetricsDashboard`, `RegistrationModal` — hardcoded Meridian emails/links replaced with `TENANT` values (including a `.tsx` mailto that extension-filtered searches had missed).
- `.env.example` — documents the variables; a retargeted deployment generates `.env.production` from the pipeline repo's `environment.yaml` via `portable-core/deploy/render.py --trust-center-env`.

This is the trust-center half of the portable "drop into any AWS env" bundle (see the companion PR in `fedramp-20x-submission-final`).

## Test plan
- Default build (no `.env`): verified all Meridian values intact in the bundle → safe for current production.
- Fully-parameterized build: verified **zero Meridian literals** in the JS bundle (API gateway, emails, docs links all replaced).
- `public/data/*` intentionally untouched — it is pipeline-synced content, replaced by the tenant's first validation run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aQRcKg9gyE4EB4jp8uS2b

---
_Generated by [Claude Code](https://claude.ai/code/session_011aQRcKg9gyE4EB4jp8uS2b)_