### PR TITLE
Whitelist frit.frb.org in registration form validation

### DIFF
--- a/src/components/modals/RegistrationModal.jsx
+++ b/src/components/modals/RegistrationModal.jsx
@@ -22,6 +22,14 @@ export const RegistrationModal = () => {
   const [submitStatus, setSubmitStatus] = useState(null);
 
   const validateEmail = (email) => {
+    // One-time domain whitelist (mirrors backend isValidFederalEmail): approved
+    // exceptions to the federal-domain rule. Exact, case-insensitive domain match.
+    // Remove entries here to revoke an exception.
+    const WHITELISTED_DOMAINS = ['frit.frb.org'];
+    const domain = String(email).split('@').pop().toLowerCase().trim();
+    if (WHITELISTED_DOMAINS.includes(domain)) {
+      return true;
+    }
     const govMilPattern = /^[^\s@]+@[^\s@]+\.(gov|mil|fed\.us)$/i; // Updated regex to match backend validation
     return govMilPattern.test(email);
   };


### PR DESCRIPTION
## Summary

Client-side counterpart to the backend `frit.frb.org` whitelist (aws_trust_center#6). The **Request Federal Agency Access** form (`RegistrationModal.jsx`) validates the email against `.gov`/`.mil`/`.fed.us` before it ever calls the API, so without this the backend exception is unreachable from the browser — the form would reject `@frit.frb.org` with *"Must be a .gov, .mil, or .fed.us email address."*

## Change

`src/components/modals/RegistrationModal.jsx` — `validateEmail()` now checks an approved-exceptions list before the federal-domain regex, mirroring the backend `isValidFederalEmail` exactly:

```js
const WHITELISTED_DOMAINS = ['frit.frb.org'];
const domain = String(email).split('@').pop().toLowerCase().trim();
if (WHITELISTED_DOMAINS.includes(domain)) return true;
const govMilPattern = /^[^\s@]+@[^\s@]+\.(gov|mil|fed\.us)$/i;
return govMilPattern.test(email);
```

- **Exact, case-insensitive domain match** — only `@frit.frb.org`; parent `frb.org` and lookalikes stay blocked.
- All other addresses unchanged. One-time exception, clearly commented; revoke by removing the array entry.

## Verification

- Unit-checked the validator against 9 cases: `frit.frb.org`/uppercase pass; `.gov`/`.mil`/`.fed.us` still pass; `frb.org`, `evilfrit.frb.org`, `example.org`, `example.com` rejected.
- `npm run build` succeeds.

## Note

Informational helper text on the form still reads ".gov, .mil, or .fed.us" — left as-is intentionally (general rule; the exception is a quiet approved allowance). Confirmed this frontend targets the same backend (`TENANT.API_URL` → `7d7pdwb9t3…/prod`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSC2nnexzDoSxausMwiUgX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSC2nnexzDoSxausMwiUgX)_