### PR TITLE
Sync CR26-keyed KSI failure tracker (de-zombied actives, lineage-tagged history)

### DIFF
--- a/public/data/ksi_failure_tracker.json
+++ b/public/data/ksi_failure_tracker.json
@@ -18,135 +18,83 @@
       "resources_failed": 0,
       "requirement": "Unknown requirement"
     },
-    "KSI-CNA-02": {
-      "ksi_id": "KSI-CNA-02",
-      "failed_at": "2026-05-11T23:48:15.169562+00:00",
-      "failed_commit": "347dea29ffb2add235bcde25a55de977f4c0ecaf",
-      "reason": "Insufficient (0%): Persistently ensure machine-based information resources have a minimal attack surface and that lateral movement is mi... | 18/27 resources compliant. CRITICAL OVERRIDE: Open ingress (0.0.0.0/0) on EC2; Open ingress (0.0.0.0/0) on EC2. | Verified: Private Subnet: '[resource]' has public IP mapping disabled (attack surface minimized).; Private Subnet: '[resource]' has public IP mapping disabled (attack surface minimized).; Private Subnet: '[resource]' has public IP mapping disabled (attack surface minimized). |   ...and 14 more verification(s) | Failures:  CRITICAL: Critical findings detected: Open ingress (0.0.0.0/0) on EC2;  CRITICAL: Critical findings detected: Open ingress (0.0.0.0/0) on EC2;  CRITICAL: Critical findings detected: Open ingress (0.0.0.0/0) on EC2 |   ...and 1 more failure(s) | Warnings: SG '[resource]' uses broad internal CIDRs ([internal-cidr] ([protocol-ports])). FedRAMP best practice: tighten ranges or use [security-group] references.; SG '[resource]' uses broad internal CIDRs ([internal-cidr] (-1 All-All), [internal-cidr] (-1 All-All)). FedRAMP best practice: tighten ranges or use [security-group] references. |   ...and 3 more warning(s)",
-      "score": 0,
-      "resources_failed": 9,
-      "requirement": "Persistently ensure machine-based information resources have a minimal attack surface and that lateral movement is minimized if compromised.",
-      "score_at_failure": 0
-    },
-    "KSI-CNA-04": {
-      "ksi_id": "KSI-CNA-04",
-      "failed_at": "2026-05-11T23:48:15.169562+00:00",
-      "failed_commit": "347dea29ffb2add235bcde25a55de977f4c0ecaf",
-      "reason": "Insufficient (0%): Use immutable infrastructure with strictly defined functionality and privileges by default. | 83/89 resources compliant. CRITICAL OVERRIDE: Open ingress (0.0.0.0/0) on EC2; All Traffic protocol open to internet. | Verified: Change notification artifact '[resource]' exists.; SG '[resource]' properly limits traffic \u2014 no world exposure, no broad CIDRs.; SG '[resource]' properly limits traffic \u2014 no world exposure, no broad CIDRs (1 [security-group] reference(s)). |   ...and 1 more verification(s) | Failures:  CRITICAL: Critical findings detected: Open ingress (0.0.0.0/0) on EC2; All Traffic protocol open to internet;  CRITICAL: Critical findings detected: Open ingress (0.0.0.0/0) on EC2; All Traffic protocol open to internet;  CRITICAL: Critical findings detected: Open ingress (0.0.0.0/0) on EC2; All Traffic protocol open to internet |   ...and 2 more failure(s) | Warnings: SG '[resource]' uses broad internal CIDRs ([internal-cidr] (-1 All-All), [internal-cidr] (-1 All-All)). FedRAMP best practice: tighten ranges or use [security-group] references.",
-      "score": 0,
-      "resources_failed": 6,
-      "requirement": "Use immutable infrastructure with strictly defined functionality and privileges by default.",
-      "score_at_failure": 0
-    },
-    "KSI-CNA-05": {
-      "ksi_id": "KSI-CNA-05",
-      "failed_at": "2026-06-15T21:32:05.248293+00:00",
-      "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
-      "reason": "Not Evaluated: Persistently review the effectiveness of protection against denial of service attacks and other unwanted activity. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
-      "score": 0,
-      "resources_failed": 0,
-      "requirement": "Persistently review the effectiveness of protection against denial of service attacks and other unwanted activity.",
-      "score_at_failure": 0
-    },
-    "KSI-IAM-01": {
-      "ksi_id": "KSI-IAM-01",
-      "failed_at": "2026-06-15T21:32:05.248293+00:00",
-      "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
-      "reason": "Not Evaluated: Enforce multi-factor authentication (MFA) using methods that are difficult to intercept or impersonate (phishing-resi... | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: Required operational metric(s) not measured this run: iam_mfa_metrics, sso_session_duration_metrics No findings produced for this KSI.",
-      "score": 0,
-      "resources_failed": 0,
-      "requirement": "Enforce multi-factor authentication (MFA) using methods that are difficult to intercept or impersonate (phishing-resistant MFA) for all user authentication.",
-      "score_at_failure": 0
-    },
-    "KSI-TPR-04": {
-      "ksi_id": "KSI-TPR-04",
-      "failed_at": "2026-06-15T21:32:05.248293+00:00",
-      "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
-      "reason": "Not Evaluated: Automatically monitor third party software information resources for upstream vulnerabilities using mechanisms that m... | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: Required operational metric(s) not measured this run: vulnerability_metrics No findings produced for this KSI.",
-      "score": 0,
-      "resources_failed": 0,
-      "requirement": "Automatically monitor third party software information resources for upstream vulnerabilities using mechanisms that may include contractual notification requirements or active monitoring services.",
-      "score_at_failure": 0
-    },
-    "KSI-IAM-03": {
-      "ksi_id": "KSI-IAM-03",
-      "failed_at": "2026-06-24T03:18:27.372697+00:00",
-      "failed_commit": "29f3c645a8dc70e73c07a8d2d69f31914c98c28f",
-      "reason": "Insufficient (98%): Enforce appropriately secure authentication methods for non-user accounts and services. | 80/82 resources compliant, 1 unverified. | Verified: RBAC Active: 1 role(s); all 1 parsed trust policies scope assumption to specific principals (no open wildcard trust). | Warnings: Found 1 programmatic IAM users (no console). Recommend migrating service workloads to IAM roles. | Verdict: Score 98% below threshold 100% (80 pass / 0 fail / 1 warning / 1 unverified).",
-      "score": 98,
-      "resources_failed": 1,
-      "requirement": "Enforce appropriately secure authentication methods for non-user accounts and services.",
-      "score_at_failure": 98
-    },
-    "KSI-MLA-01": {
-      "ksi_id": "KSI-MLA-01",
-      "failed_at": "2026-07-03T17:05:51.763902+00:00",
-      "failed_commit": "3992eb9cbe88c155cd44f6c91ea46f21e4632733",
-      "reason": "Insufficient (100%): Log all activity on all information resources supporting the cloud service offering to a protected audit log. | 3/5 resources compliant, 2 unverified. | Verified: Trail is Secure (Multi-Region, Validated, KMS-Encrypted, Global Events) [organization trail; CloudWatch Logs integrated \u2192 arn:aws:[redacted]; delivery role arn:aws:[redacted]; Trail logging rate 100% (1/1 trails actively logging).; S3 access-logging rate 100% (11 buckets covered). | Verdict: Required operational metric(s) not measured this run: alb_access_log_metrics",
-      "score": 100,
-      "resources_failed": 0,
-      "requirement": "Log all activity on all information resources supporting the cloud service offering to a protected audit log.",
-      "score_at_failure": 100
-    },
     "KSI-CNA-DFP": {
       "ksi_id": "KSI-CNA-DFP",
-      "failed_at": "2026-07-06T17:51:14.723954+00:00",
+      "failed_at": "2026-05-11T23:48:15.169562+00:00",
       "failed_commit": "7c45425353c738d0b9076222ff2a03bccb244011",
       "reason": "Insufficient (98%): The functionality and privileges for infrastructure and services are strictly defined. | 82/84 resources compliant. | Verified: Verified: Governance document '[resource]' is substantive (1070 bytes, 4 sections).; SG '[resource]' properly limits traffic \u2014 no world exposure, no broad CIDRs [4 scoped internal-CIDR rule(s); egress restricted].; RBAC Active: 1 role(s); all 1 parsed trust policies scope assumption to specific principals (no open wildcard trust). | Warnings: SG '[resource]' allows all-protocol/all-port traffic from broad internal CIDRs ([internal-cidr] (-1 All-All), [internal-cidr] (-1 All-All), [internal-cidr] (-1 All-All)). FedRAMP best practice: scope these to specific ports or use [security-group] references.; SG '[resource]' allows all-protocol/all-port traffic from broad internal CIDRs ([internal-cidr] (-1 All-All)). FedRAMP best practice: scope these to specific ports or use [security-group] references. | Verdict: Score 98% below threshold 100% (82 pass / 0 fail / 1 warning / 0 unverified).",
       "score": 98,
       "resources_failed": 1,
       "requirement": "The functionality and privileges for infrastructure and services are strictly defined.",
-      "score_at_failure": 98
+      "score_at_failure": 98,
+      "legacy_ksi_id": [
+        "KSI-CNA-04"
+      ]
     },
     "KSI-CNA-MAT": {
       "ksi_id": "KSI-CNA-MAT",
-      "failed_at": "2026-07-06T17:51:14.723954+00:00",
+      "failed_at": "2026-05-11T23:48:15.169562+00:00",
       "failed_commit": "7c45425353c738d0b9076222ff2a03bccb244011",
       "reason": "Insufficient (95%): Machine-based information resources are persistently reviewed to ensure they have a minimal attack surface and that l... | 20/22 resources compliant. | Verified: Private Subnet: '[resource]' has public IP mapping disabled (attack surface minimized).; Private Subnet: '[resource]' has public IP mapping disabled (attack surface minimized).; Private Subnet: '[resource]' has public IP mapping disabled (attack surface minimized). |   ...and 17 more verification(s) | Warnings: SG '[resource]' allows all-protocol/all-port traffic from broad internal CIDRs ([internal-cidr] (-1 All-All), [internal-cidr] (-1 All-All), [internal-cidr] (-1 All-All)). FedRAMP best practice: scope these to specific ports or use [security-group] references.; SG '[resource]' allows all-protocol/all-port traffic from broad internal CIDRs ([internal-cidr] (-1 All-All)). FedRAMP best practice: scope these to specific ports or use [security-group] references. | Verdict: Score 95% below threshold 100% (20 pass / 0 fail / 1 warning / 0 unverified).",
       "score": 95,
       "resources_failed": 1,
       "requirement": "Machine-based information resources are persistently reviewed to ensure they have a minimal attack surface and that lateral movement is minimized if compromised.",
-      "score_at_failure": 95
+      "score_at_failure": 95,
+      "legacy_ksi_id": [
+        "KSI-CNA-02"
+      ]
     },
     "KSI-CNA-RVP": {
       "ksi_id": "KSI-CNA-RVP",
-      "failed_at": "2026-07-06T17:51:14.723954+00:00",
+      "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "7c45425353c738d0b9076222ff2a03bccb244011",
       "reason": "Insufficient (80%): The effectiveness of protection against denial of service attacks and other unwanted activity for machine-based infor... | 4/6 resources compliant, 1 unverified. | Verified: WAF protection active: 1 Web ACL(s) configured for Layer 7 defense.; 1 load balancer(s) covered by AWS Shield Standard \u2014 automatic, always-on Layer 3/4 DDoS protection for all AWS load balancers (no subscription required; AWS baseline).; DNS resilience: 1 Route53 hosted zone(s) on AWS AnyCast network. | Failures: API stage throttle coverage 0% < target 100% (3/3 stages without throttle \u2014 sample: 30r7mtjz87:prod; 7d7pdwb9t3:Stage; 7d7pdwb9t3:prod). Bulk-API exfiltration risk. | Verdict: Score 80% below threshold 100% (4 pass / 1 fail / 0 warning / 1 unverified).",
       "score": 80,
       "resources_failed": 1,
       "requirement": "The effectiveness of protection against denial of service attacks and other unwanted activity for machine-based information resources is persistently reviewed.",
-      "score_at_failure": 80
+      "score_at_failure": 80,
+      "legacy_ksi_id": [
+        "KSI-CNA-05"
+      ]
     },
     "KSI-IAM-APM": {
       "ksi_id": "KSI-IAM-APM",
-      "failed_at": "2026-07-06T17:51:14.723954+00:00",
+      "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "7c45425353c738d0b9076222ff2a03bccb244011",
       "reason": "Insufficient (45%): Secure passwordless methods are used for user authentication and authorization when feasible, otherwise strong passwo... | 5/11 resources compliant, 6 unverified. | Verified: Modern Identity: AWS Identity Center is active.; Federated auth: 1 SAML provider(s) configured. | Verdict: Required operational metric(s) not measured this run: iam_mfa_metrics, sso_session_duration_metrics",
       "score": 45,
       "resources_failed": 0,
       "requirement": "Secure passwordless methods are used for user authentication and authorization when feasible, otherwise strong passwords with phishing-resistant MFA is used.",
-      "score_at_failure": 45
+      "score_at_failure": 45,
+      "legacy_ksi_id": [
+        "KSI-IAM-01"
+      ]
     },
     "KSI-IAM-SNU": {
       "ksi_id": "KSI-IAM-SNU",
-      "failed_at": "2026-07-06T17:51:14.723954+00:00",
+      "failed_at": "2026-06-24T03:18:27.372697+00:00",
       "failed_commit": "7c45425353c738d0b9076222ff2a03bccb244011",
       "reason": "Insufficient (98%): Appropriately secure authentication methods are used and persistently reviewed for non-user accounts and services. | 80/82 resources compliant, 1 unverified. | Verified: RBAC Active: 1 role(s); all 1 parsed trust policies scope assumption to specific principals (no open wildcard trust). | Warnings: Found 1 programmatic IAM users (no console). Recommend migrating service workloads to IAM roles. | Verdict: Score 98% below threshold 100% (80 pass / 0 fail / 1 warning / 1 unverified).",
       "score": 98,
       "resources_failed": 1,
       "requirement": "Appropriately secure authentication methods are used and persistently reviewed for non-user accounts and services.",
-      "score_at_failure": 98
+      "score_at_failure": 98,
+      "legacy_ksi_id": [
+        "KSI-IAM-03"
+      ]
     },
     "KSI-MLA-OSM": {
       "ksi_id": "KSI-MLA-OSM",
-      "failed_at": "2026-07-06T17:51:14.723954+00:00",
+      "failed_at": "2026-07-03T17:05:51.763902+00:00",
       "failed_commit": "7c45425353c738d0b9076222ff2a03bccb244011",
       "reason": "Insufficient (100%): A Security Information and Event Management (SIEM) or similar system(s) is used and persistently reviewed for central... | 3/5 resources compliant, 2 unverified. | Verified: Trail is Secure (Multi-Region, Validated, KMS-Encrypted, Global Events) [organization trail; CloudWatch Logs integrated \u2192 arn:aws:[redacted]; delivery role arn:aws:[redacted]; Trail logging rate 100% (1/1 trails actively logging).; S3 access-logging rate 100% (11 buckets covered). | Verdict: Required operational metric(s) not measured this run: alb_access_log_metrics",
       "score": 100,
       "resources_failed": 0,
       "requirement": "A Security Information and Event Management (SIEM) or similar system(s) is used and persistently reviewed for centralized, tamper-resistant logging of events, activities, and changes.",
-      "score_at_failure": 100
+      "score_at_failure": 100,
+      "legacy_ksi_id": [
+        "KSI-MLA-01"
+      ]
     },
     "KSI-CMT-RMV": {
       "ksi_id": "KSI-CMT-RMV",
@@ -167,11 +115,24 @@
       "resources_failed": 2,
       "requirement": "The use and configuration of third-party machine-based information resources is persistently compared against the original provider's best practices and guidance.",
       "score_at_failure": 95
+    },
+    "KSI-SCR-MON": {
+      "ksi_id": "KSI-TPR-04",
+      "failed_at": "2026-06-15T21:32:05.248293+00:00",
+      "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
+      "reason": "Not Evaluated: Automatically monitor third party software information resources for upstream vulnerabilities using mechanisms that m... | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: Required operational metric(s) not measured this run: vulnerability_metrics No findings produced for this KSI.",
+      "score": 0,
+      "resources_failed": 0,
+      "requirement": "Automatically monitor third party software information resources for upstream vulnerabilities using mechanisms that may include contractual notification requirements or active monitoring services.",
+      "score_at_failure": 0,
+      "legacy_ksi_id": [
+        "KSI-TPR-04"
+      ]
     }
   },
   "failure_history": [
     {
-      "ksi_id": "KSI-INR-03",
+      "ksi_id": "KSI-INR-AAR",
       "failed_at": "2025-05-30T04:00:36Z",
       "failed_commit": "96d93ea8310f66d4a5c3da98170b64d242843dcc",
       "reason": "CLI command failed: An error occurred (ThrottlingException) when calling the ListDocuments operation (reached max retries: 2): Rate exceeded",
@@ -180,10 +141,11 @@
       "requirement": "A secure cloud service offering will document, report, and analyze security incidents to ensure regulatory compliance and continuous security improvement.",
       "remediated_at": "2025-05-30T04:19:36Z",
       "remediation_commit": "ae42d331bc0750b1b1f3bfb8ce8875760af3a8ce",
-      "duration_hours": 0.32
+      "duration_hours": 0.32,
+      "legacy_ksi_id": "KSI-INR-03"
     },
     {
-      "ksi_id": "KSI-CNA-05",
+      "ksi_id": "KSI-CNA-RVP",
       "failed_at": "2025-05-29T21:06:01Z",
       "failed_commit": "3b89e496c5ce8cb9806f032ff8ddc4a97fd412ff",
       "reason": "CLI command failed: An error occurred (ResourceNotFoundException) when calling the ListProtections operation: The subscription does not exist.",
@@ -192,10 +154,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-01T00:59:39Z",
       "remediation_commit": "801d960addf4791e410ddb0c005eefd338b5be16",
-      "duration_hours": 51.89
+      "duration_hours": 51.89,
+      "legacy_ksi_id": "KSI-CNA-05"
     },
     {
-      "ksi_id": "KSI-CNA-02",
+      "ksi_id": "KSI-CNA-MAT",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -204,10 +167,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-CNA-02"
     },
     {
-      "ksi_id": "KSI-CMT-03",
+      "ksi_id": "KSI-CMT-VTD",
       "failed_at": "2025-06-01T00:59:39Z",
       "failed_commit": "801d960addf4791e410ddb0c005eefd338b5be16",
       "reason": "CLI command failed: usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]\nTo see help text, you can run:\n\n  aws help\n  aws <command> help\n  aws <command> <subcommand> help\n\naws: error: the following arguments are required: --names",
@@ -216,10 +180,11 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 10.98
+      "duration_hours": 10.98,
+      "legacy_ksi_id": "KSI-CMT-03"
     },
     {
-      "ksi_id": "KSI-IAM-06",
+      "ksi_id": "KSI-IAM-SUS",
       "failed_at": "2025-05-29T21:06:01Z",
       "failed_commit": "3b89e496c5ce8cb9806f032ff8ddc4a97fd412ff",
       "reason": "CLI command failed: An error occurred (NoSuchEntity) when calling the GetAccountPasswordPolicy operation: The Password Policy with domain name 155765116562 cannot be found.",
@@ -228,7 +193,8 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 62.87
+      "duration_hours": 62.87,
+      "legacy_ksi_id": "KSI-IAM-06"
     },
     {
       "ksi_id": "KSI-SVC-07",
@@ -240,10 +206,12 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-SVC-07",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-CNA-01",
+      "ksi_id": "KSI-CNA-RNT",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -252,10 +220,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-CNA-01"
     },
     {
-      "ksi_id": "KSI-IAM-01",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -264,10 +233,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-IAM-01"
     },
     {
-      "ksi_id": "KSI-CED-01",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-05-29T21:06:01Z",
       "failed_commit": "3b89e496c5ce8cb9806f032ff8ddc4a97fd412ff",
       "reason": "CLI command failed: usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]\nTo see help text, you can run:\n\n  aws help\n  aws <command> help\n  aws <command> <subcommand> help\n\naws: error: argument operation: Invalid choice, valid choices are:\n\nget-role-credentials                     | list-account-roles                      \nlist-accounts                            | logout                                  \nlogin                                    | help",
@@ -276,10 +246,11 @@
       "requirement": "A secure cloud service provider will continuously educate their employees on cybersecurity measures, testing them regularly to ensure their knowledge is satisfactory.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 62.87
+      "duration_hours": 62.87,
+      "legacy_ksi_id": "KSI-CED-01"
     },
     {
-      "ksi_id": "KSI-CMT-01",
+      "ksi_id": "KSI-CMT-LMC",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -288,10 +259,11 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-CMT-01"
     },
     {
-      "ksi_id": "KSI-MLA-02",
+      "ksi_id": "KSI-MLA-RVL",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -300,10 +272,11 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-MLA-02"
     },
     {
-      "ksi_id": "KSI-PIY-03",
+      "ksi_id": "KSI-PIY-RVD",
       "failed_at": "2025-05-29T21:06:01Z",
       "failed_commit": "3b89e496c5ce8cb9806f032ff8ddc4a97fd412ff",
       "reason": "CLI command failed: An error occurred (SubscriptionRequiredException) when calling the DescribeTrustedAdvisorChecks operation: Amazon Web Services Premium Support Subscription is required to use this service.",
@@ -312,10 +285,11 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 62.87
+      "duration_hours": 62.87,
+      "legacy_ksi_id": "KSI-PIY-03"
     },
     {
-      "ksi_id": "KSI-SVC-01",
+      "ksi_id": "KSI-SVC-EIS",
       "failed_at": "2025-06-01T00:59:39Z",
       "failed_commit": "801d960addf4791e410ddb0c005eefd338b5be16",
       "reason": "CLI command failed: usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]\nTo see help text, you can run:\n\n  aws help\n  aws <command> help\n  aws <command> <subcommand> help\n\naws: error: the following arguments are required: --scope",
@@ -324,10 +298,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 10.98
+      "duration_hours": 10.98,
+      "legacy_ksi_id": "KSI-SVC-01"
     },
     {
-      "ksi_id": "KSI-CNA-07",
+      "ksi_id": "KSI-CNA-IBP",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -336,10 +311,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-CNA-07"
     },
     {
-      "ksi_id": "KSI-PIY-06",
+      "ksi_id": "KSI-PIY-RIS",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -348,10 +324,11 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-PIY-06"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -360,10 +337,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-CMT-04",
+      "ksi_id": "KSI-CMT-RVP",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -372,7 +350,8 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-CMT-04"
     },
     {
       "ksi_id": "KSI-MLA-06",
@@ -384,10 +363,12 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 62.87
+      "duration_hours": 62.87,
+      "legacy_ksi_id": "KSI-MLA-06",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-TPR-04",
+      "ksi_id": "KSI-SCR-MON",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -396,10 +377,11 @@
       "requirement": "A secure cloud service offering will understand, monitor, and manage supply chain risks from third-party information resources.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-TPR-04"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -408,7 +390,8 @@
       "requirement": "A secure cloud service offering will document, report, and analyze security incidents to ensure regulatory compliance and continuous security improvement.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
       "ksi_id": "KSI-PIY-05",
@@ -420,10 +403,12 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 62.87
+      "duration_hours": 62.87,
+      "legacy_ksi_id": "KSI-PIY-05",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -432,10 +417,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
-      "ksi_id": "KSI-INR-03",
+      "ksi_id": "KSI-INR-AAR",
       "failed_at": "2025-06-01T00:59:39Z",
       "failed_commit": "801d960addf4791e410ddb0c005eefd338b5be16",
       "reason": "CLI command failed: An error occurred (AccessDeniedException) when calling the ListFindings operation:",
@@ -444,7 +430,8 @@
       "requirement": "A secure cloud service offering will document, report, and analyze security incidents to ensure regulatory compliance and continuous security improvement.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 10.98
+      "duration_hours": 10.98,
+      "legacy_ksi_id": "KSI-INR-03"
     },
     {
       "ksi_id": "KSI-PIY-02",
@@ -456,10 +443,12 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-PIY-02",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-CNA-05",
+      "ksi_id": "KSI-CNA-RVP",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -468,7 +457,8 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-CNA-05"
     },
     {
       "ksi_id": "KSI-MLA-03",
@@ -480,10 +470,12 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 10.98
+      "duration_hours": 10.98,
+      "legacy_ksi_id": "KSI-MLA-03",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-SVC-04",
+      "ksi_id": "KSI-SVC-ACM",
       "failed_at": "2025-05-29T21:06:01Z",
       "failed_commit": "3b89e496c5ce8cb9806f032ff8ddc4a97fd412ff",
       "reason": "CLI command failed: usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]\nTo see help text, you can run:\n\n  aws help\n  aws <command> help\n  aws <command> <subcommand> help\n\naws: error: argument command: Invalid choice, valid choices are:\n\naccessanalyzer                           | account                                 \nacm                                      | acm-pca                                 \namp                                      | amplify                     ",
@@ -492,10 +484,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 62.87
+      "duration_hours": 62.87,
+      "legacy_ksi_id": "KSI-SVC-04"
     },
     {
-      "ksi_id": "KSI-CNA-06",
+      "ksi_id": "KSI-CNA-OFA",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -504,10 +497,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-CNA-06"
     },
     {
-      "ksi_id": "KSI-PIY-01",
+      "ksi_id": "KSI-PIY-GIV",
       "failed_at": "2025-05-29T21:06:01Z",
       "failed_commit": "3b89e496c5ce8cb9806f032ff8ddc4a97fd412ff",
       "reason": "CLI command failed: usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]\nTo see help text, you can run:\n\n  aws help\n  aws <command> help\n  aws <command> <subcommand> help\n\naws: error: argument command: Invalid choice, valid choices are:\n\naccessanalyzer                           | account                                 \nacm                                      | acm-pca                                 \namp                                      | amplify                     ",
@@ -516,10 +510,11 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 62.87
+      "duration_hours": 62.87,
+      "legacy_ksi_id": "KSI-PIY-01"
     },
     {
-      "ksi_id": "KSI-PIY-04",
+      "ksi_id": "KSI-PIY-RSD",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -528,10 +523,11 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-PIY-04"
     },
     {
-      "ksi_id": "KSI-CNA-04",
+      "ksi_id": "KSI-CNA-DFP",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -540,7 +536,8 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-CNA-04"
     },
     {
       "ksi_id": "KSI-TPR-01",
@@ -552,10 +549,12 @@
       "requirement": "A secure cloud service offering will understand, monitor, and manage supply chain risks from third-party information resources.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 62.87
+      "duration_hours": 62.87,
+      "legacy_ksi_id": "KSI-TPR-01",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-CMT-02",
+      "ksi_id": "KSI-CMT-RMV",
       "failed_at": "2025-05-29T21:06:01Z",
       "failed_commit": "3b89e496c5ce8cb9806f032ff8ddc4a97fd412ff",
       "reason": "CLI command failed: An error occurred (AccessDenied) when calling the ListObjectVersions operation: Access Denied",
@@ -564,7 +563,8 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 62.87
+      "duration_hours": 62.87,
+      "legacy_ksi_id": "KSI-CMT-02"
     },
     {
       "ksi_id": "KSI-SVC-03",
@@ -576,7 +576,9 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-SVC-03",
+      "retired_pre_cr26": true
     },
     {
       "ksi_id": "KSI-TPR-02",
@@ -588,10 +590,12 @@
       "requirement": "A secure cloud service offering will understand, monitor, and manage supply chain risks from third-party information resources.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-TPR-02",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-SVC-05",
+      "ksi_id": "KSI-SVC-VRI",
       "failed_at": "2025-06-01T00:59:39Z",
       "failed_commit": "801d960addf4791e410ddb0c005eefd338b5be16",
       "reason": "CLI command failed: An error occurred (ResourceNotFoundException) when calling the DescribeDRTAccess operation: The subscription does not exist.",
@@ -600,10 +604,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 10.98
+      "duration_hours": 10.98,
+      "legacy_ksi_id": "KSI-SVC-05"
     },
     {
-      "ksi_id": "KSI-RPL-02",
+      "ksi_id": "KSI-RPL-ARP",
       "failed_at": "2025-05-29T21:06:01Z",
       "failed_commit": "3b89e496c5ce8cb9806f032ff8ddc4a97fd412ff",
       "reason": "CLI command failed: An error occurred (AccessDeniedException) when calling the ListRecoveryPointsByBackupVault operation: Insufficient privileges to perform this action.",
@@ -612,10 +617,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 62.87
+      "duration_hours": 62.87,
+      "legacy_ksi_id": "KSI-RPL-02"
     },
     {
-      "ksi_id": "KSI-MLA-05",
+      "ksi_id": "KSI-MLA-EVC",
       "failed_at": "2025-05-29T21:06:01Z",
       "failed_commit": "3b89e496c5ce8cb9806f032ff8ddc4a97fd412ff",
       "reason": "CLI command failed: usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]\nTo see help text, you can run:\n\n  aws help\n  aws <command> help\n  aws <command> <subcommand> help\n\naws: error: argument command: Invalid choice, valid choices are:\n\naccessanalyzer                           | account                                 \nacm                                      | acm-pca                                 \namp                                      | amplify                     ",
@@ -624,7 +630,8 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 62.87
+      "duration_hours": 62.87,
+      "legacy_ksi_id": "KSI-MLA-05"
     },
     {
       "ksi_id": "KSI-MLA-04",
@@ -636,10 +643,12 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-MLA-04",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-IAM-04",
+      "ksi_id": "KSI-IAM-JIT",
       "failed_at": "2025-05-29T21:06:01Z",
       "failed_commit": "3b89e496c5ce8cb9806f032ff8ddc4a97fd412ff",
       "reason": "CLI command failed: usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]\nTo see help text, you can run:\n\n  aws help\n  aws <command> help\n  aws <command> <subcommand> help\n\naws: error: the following arguments are required: --role-name",
@@ -648,10 +657,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 62.87
+      "duration_hours": 62.87,
+      "legacy_ksi_id": "KSI-IAM-04"
     },
     {
-      "ksi_id": "KSI-SVC-06",
+      "ksi_id": "KSI-SVC-ASM",
       "failed_at": "2025-05-29T21:06:01Z",
       "failed_commit": "3b89e496c5ce8cb9806f032ff8ddc4a97fd412ff",
       "reason": "CLI command failed: usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]\nTo see help text, you can run:\n\n  aws help\n  aws <command> help\n  aws <command> <subcommand> help\n\naws: error: argument operation: Invalid choice, valid choices are:\n\ncancel-key-deletion                      | connect-custom-key-store                \ncreate-alias                             | create-custom-key-store                 \ncreate-grant                             | create-key                ",
@@ -660,10 +670,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 62.87
+      "duration_hours": 62.87,
+      "legacy_ksi_id": "KSI-SVC-06"
     },
     {
-      "ksi_id": "KSI-TPR-03",
+      "ksi_id": "KSI-SCR-MIT",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -672,10 +683,11 @@
       "requirement": "A secure cloud service offering will understand, monitor, and manage supply chain risks from third-party information resources.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-TPR-03"
     },
     {
-      "ksi_id": "KSI-SVC-02",
+      "ksi_id": "KSI-SVC-SIN",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -684,10 +696,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-SVC-02"
     },
     {
-      "ksi_id": "KSI-IAM-05",
+      "ksi_id": "KSI-IAM-ELP",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -696,7 +709,8 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-IAM-05"
     },
     {
       "ksi_id": "KSI-PIY-07",
@@ -708,10 +722,12 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 62.87
+      "duration_hours": 62.87,
+      "legacy_ksi_id": "KSI-PIY-07",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-INR-01",
+      "ksi_id": "KSI-INR-RIR",
       "failed_at": "2025-05-29T21:06:01Z",
       "failed_commit": "3b89e496c5ce8cb9806f032ff8ddc4a97fd412ff",
       "reason": "CLI command failed: usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]\nTo see help text, you can run:\n\n  aws help\n  aws <command> help\n  aws <command> <subcommand> help\n\naws: error: argument operation: Invalid choice, valid choices are:\n\naccept-administrator-invitation          | accept-invitation                       \nbatch-delete-automation-rules            | batch-disable-standards                 \nbatch-enable-standards                   | batch-get-automation-rules",
@@ -720,10 +736,11 @@
       "requirement": "A secure cloud service offering will document, report, and analyze security incidents to ensure regulatory compliance and continuous security improvement.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 62.87
+      "duration_hours": 62.87,
+      "legacy_ksi_id": "KSI-INR-01"
     },
     {
-      "ksi_id": "KSI-CNA-03",
+      "ksi_id": "KSI-CNA-ULN",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -732,10 +749,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-CNA-03"
     },
     {
-      "ksi_id": "KSI-IAM-02",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -744,7 +762,8 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-IAM-02"
     },
     {
       "ksi_id": "KSI-CMT-05",
@@ -756,10 +775,12 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-CMT-05",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -768,10 +789,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-IAM-03",
+      "ksi_id": "KSI-IAM-SNU",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -780,10 +802,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-IAM-03"
     },
     {
-      "ksi_id": "KSI-MLA-01",
+      "ksi_id": "KSI-MLA-OSM",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -792,10 +815,11 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-01T11:58:24Z",
       "remediation_commit": "c535d4d6d24a915fbd5081b91004876b00a3a7b2",
-      "duration_hours": 1.53
+      "duration_hours": 1.53,
+      "legacy_ksi_id": "KSI-MLA-01"
     },
     {
-      "ksi_id": "KSI-CNA-02",
+      "ksi_id": "KSI-CNA-MAT",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No subnets found",
@@ -804,10 +828,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-01T15:07:18Z",
       "remediation_commit": "c9b74f0a481789a630214b9c79e08974d24d0cf5",
-      "duration_hours": 0.29
+      "duration_hours": 0.29,
+      "legacy_ksi_id": "KSI-CNA-02"
     },
     {
-      "ksi_id": "KSI-CNA-01",
+      "ksi_id": "KSI-CNA-RNT",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No Network ACLs found",
@@ -816,10 +841,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-01T15:07:18Z",
       "remediation_commit": "c9b74f0a481789a630214b9c79e08974d24d0cf5",
-      "duration_hours": 0.29
+      "duration_hours": 0.29,
+      "legacy_ksi_id": "KSI-CNA-01"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No backup plans found",
@@ -828,10 +854,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-01T15:07:18Z",
       "remediation_commit": "c9b74f0a481789a630214b9c79e08974d24d0cf5",
-      "duration_hours": 0.29
+      "duration_hours": 0.29,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No SecurityHub findings found",
@@ -840,7 +867,8 @@
       "requirement": "A secure cloud service offering will document, report, and analyze security incidents to ensure regulatory compliance and continuous security improvement.",
       "remediated_at": "2025-06-01T15:07:18Z",
       "remediation_commit": "c9b74f0a481789a630214b9c79e08974d24d0cf5",
-      "duration_hours": 0.29
+      "duration_hours": 0.29,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
       "ksi_id": "KSI-PIY-02",
@@ -852,10 +880,12 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-01T15:07:18Z",
       "remediation_commit": "c9b74f0a481789a630214b9c79e08974d24d0cf5",
-      "duration_hours": 0.29
+      "duration_hours": 0.29,
+      "legacy_ksi_id": "KSI-PIY-02",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-CNA-05",
+      "ksi_id": "KSI-CNA-RVP",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No VPCs found",
@@ -864,10 +894,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-01T15:07:18Z",
       "remediation_commit": "c9b74f0a481789a630214b9c79e08974d24d0cf5",
-      "duration_hours": 0.29
+      "duration_hours": 0.29,
+      "legacy_ksi_id": "KSI-CNA-05"
     },
     {
-      "ksi_id": "KSI-CNA-06",
+      "ksi_id": "KSI-CNA-OFA",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No route tables found",
@@ -876,7 +907,8 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-01T15:07:18Z",
       "remediation_commit": "c9b74f0a481789a630214b9c79e08974d24d0cf5",
-      "duration_hours": 0.29
+      "duration_hours": 0.29,
+      "legacy_ksi_id": "KSI-CNA-06"
     },
     {
       "ksi_id": "KSI-SVC-03",
@@ -888,10 +920,12 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-01T15:07:18Z",
       "remediation_commit": "c9b74f0a481789a630214b9c79e08974d24d0cf5",
-      "duration_hours": 0.29
+      "duration_hours": 0.29,
+      "legacy_ksi_id": "KSI-SVC-03",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-IAM-05",
+      "ksi_id": "KSI-IAM-ELP",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No account authorization details found",
@@ -900,10 +934,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-01T15:07:18Z",
       "remediation_commit": "c9b74f0a481789a630214b9c79e08974d24d0cf5",
-      "duration_hours": 0.29
+      "duration_hours": 0.29,
+      "legacy_ksi_id": "KSI-IAM-05"
     },
     {
-      "ksi_id": "KSI-CNA-03",
+      "ksi_id": "KSI-CNA-ULN",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No security groups found",
@@ -912,10 +947,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-01T15:07:18Z",
       "remediation_commit": "c9b74f0a481789a630214b9c79e08974d24d0cf5",
-      "duration_hours": 0.29
+      "duration_hours": 0.29,
+      "legacy_ksi_id": "KSI-CNA-03"
     },
     {
-      "ksi_id": "KSI-IAM-02",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No IAM users found",
@@ -924,10 +960,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-01T15:07:18Z",
       "remediation_commit": "c9b74f0a481789a630214b9c79e08974d24d0cf5",
-      "duration_hours": 0.29
+      "duration_hours": 0.29,
+      "legacy_ksi_id": "KSI-IAM-02"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No backup jobs found",
@@ -936,10 +973,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-01T15:07:18Z",
       "remediation_commit": "c9b74f0a481789a630214b9c79e08974d24d0cf5",
-      "duration_hours": 0.29
+      "duration_hours": 0.29,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-IAM-03",
+      "ksi_id": "KSI-IAM-SNU",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No IAM roles found",
@@ -948,10 +986,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-01T15:07:18Z",
       "remediation_commit": "c9b74f0a481789a630214b9c79e08974d24d0cf5",
-      "duration_hours": 0.29
+      "duration_hours": 0.29,
+      "legacy_ksi_id": "KSI-IAM-03"
     },
     {
-      "ksi_id": "KSI-MLA-01",
+      "ksi_id": "KSI-MLA-OSM",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No log groups found",
@@ -960,10 +999,11 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-01T15:07:18Z",
       "remediation_commit": "c9b74f0a481789a630214b9c79e08974d24d0cf5",
-      "duration_hours": 0.29
+      "duration_hours": 0.29,
+      "legacy_ksi_id": "KSI-MLA-01"
     },
     {
-      "ksi_id": "KSI-CED-01",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No SSO users found",
@@ -972,10 +1012,11 @@
       "requirement": "A secure cloud service provider will continuously educate their employees on cybersecurity measures, testing them regularly to ensure their knowledge is satisfactory.",
       "remediated_at": "2025-06-03T01:06:31Z",
       "remediation_commit": "046413fbfc5b70b6ff327167ee064e8c0ccb7e2e",
-      "duration_hours": 34.28
+      "duration_hours": 34.28,
+      "legacy_ksi_id": "KSI-CED-01"
     },
     {
-      "ksi_id": "KSI-CNA-01",
+      "ksi_id": "KSI-CNA-RNT",
       "failed_at": "2025-06-03T01:06:31Z",
       "failed_commit": "046413fbfc5b70b6ff327167ee064e8c0ccb7e2e",
       "reason": "No Network ACLs found",
@@ -984,10 +1025,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-03T06:01:16Z",
       "remediation_commit": "ad13894e14a4e819629942ec77243f598a02f964",
-      "duration_hours": 4.91
+      "duration_hours": 4.91,
+      "legacy_ksi_id": "KSI-CNA-01"
     },
     {
-      "ksi_id": "KSI-PIY-06",
+      "ksi_id": "KSI-PIY-RIS",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No organization structure found",
@@ -996,10 +1038,11 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-03T06:01:16Z",
       "remediation_commit": "ad13894e14a4e819629942ec77243f598a02f964",
-      "duration_hours": 39.19
+      "duration_hours": 39.19,
+      "legacy_ksi_id": "KSI-PIY-06"
     },
     {
-      "ksi_id": "KSI-CNA-03",
+      "ksi_id": "KSI-CNA-ULN",
       "failed_at": "2025-06-03T01:06:31Z",
       "failed_commit": "046413fbfc5b70b6ff327167ee064e8c0ccb7e2e",
       "reason": "No security groups found",
@@ -1008,10 +1051,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-03T06:01:16Z",
       "remediation_commit": "ad13894e14a4e819629942ec77243f598a02f964",
-      "duration_hours": 4.91
+      "duration_hours": 4.91,
+      "legacy_ksi_id": "KSI-CNA-03"
     },
     {
-      "ksi_id": "KSI-IAM-06",
+      "ksi_id": "KSI-IAM-SUS",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No password policy found",
@@ -1020,10 +1064,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-03T20:37:00Z",
       "remediation_commit": "3bfc08da1dd0da4233a311d6b48723dee1c13938",
-      "duration_hours": 53.78
+      "duration_hours": 53.78,
+      "legacy_ksi_id": "KSI-IAM-06"
     },
     {
-      "ksi_id": "KSI-MLA-02",
+      "ksi_id": "KSI-MLA-RVL",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No metric filters found",
@@ -1032,10 +1077,11 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-03T20:37:00Z",
       "remediation_commit": "3bfc08da1dd0da4233a311d6b48723dee1c13938",
-      "duration_hours": 53.78
+      "duration_hours": 53.78,
+      "legacy_ksi_id": "KSI-MLA-02"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-06-03T06:01:16Z",
       "failed_commit": "ad13894e14a4e819629942ec77243f598a02f964",
       "reason": "No confirm backup rto (Items) found",
@@ -1044,7 +1090,8 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-03T21:57:26Z",
       "remediation_commit": "c390802d685a95c3678c7db2fdd44cfc727d0760",
-      "duration_hours": 15.94
+      "duration_hours": 15.94,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
       "ksi_id": "KSI-MLA-06",
@@ -1056,10 +1103,12 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-03T21:57:26Z",
       "remediation_commit": "c390802d685a95c3678c7db2fdd44cfc727d0760",
-      "duration_hours": 55.12
+      "duration_hours": 55.12,
+      "legacy_ksi_id": "KSI-MLA-06",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-TPR-04",
+      "ksi_id": "KSI-SCR-MON",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No Inspector findings found",
@@ -1068,10 +1117,11 @@
       "requirement": "A secure cloud service offering will understand, monitor, and manage supply chain risks from third-party information resources.",
       "remediated_at": "2025-06-03T21:57:26Z",
       "remediation_commit": "c390802d685a95c3678c7db2fdd44cfc727d0760",
-      "duration_hours": 55.12
+      "duration_hours": 55.12,
+      "legacy_ksi_id": "KSI-TPR-04"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2025-06-03T01:06:31Z",
       "failed_commit": "046413fbfc5b70b6ff327167ee064e8c0ccb7e2e",
       "reason": "No SecurityHub findings found",
@@ -1080,10 +1130,11 @@
       "requirement": "A secure cloud service offering will document, report, and analyze security incidents to ensure regulatory compliance and continuous security improvement.",
       "remediated_at": "2025-06-03T23:19:06Z",
       "remediation_commit": "3c8805924ab4106d2168564ea2787c24e3ce5f09",
-      "duration_hours": 22.21
+      "duration_hours": 22.21,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No restore jobs found",
@@ -1092,7 +1143,8 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-03T23:19:06Z",
       "remediation_commit": "3c8805924ab4106d2168564ea2787c24e3ce5f09",
-      "duration_hours": 56.48
+      "duration_hours": 56.48,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
       "ksi_id": "KSI-PIY-02",
@@ -1104,10 +1156,12 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-03T23:19:06Z",
       "remediation_commit": "3c8805924ab4106d2168564ea2787c24e3ce5f09",
-      "duration_hours": 22.21
+      "duration_hours": 22.21,
+      "legacy_ksi_id": "KSI-PIY-02",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-PIY-01",
+      "ksi_id": "KSI-PIY-GIV",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No discovered resources",
@@ -1116,10 +1170,11 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-03T23:19:06Z",
       "remediation_commit": "3c8805924ab4106d2168564ea2787c24e3ce5f09",
-      "duration_hours": 56.48
+      "duration_hours": 56.48,
+      "legacy_ksi_id": "KSI-PIY-01"
     },
     {
-      "ksi_id": "KSI-PIY-04",
+      "ksi_id": "KSI-PIY-RSD",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No CodeCommit repositories found",
@@ -1128,10 +1183,11 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-03T23:19:06Z",
       "remediation_commit": "3c8805924ab4106d2168564ea2787c24e3ce5f09",
-      "duration_hours": 56.48
+      "duration_hours": 56.48,
+      "legacy_ksi_id": "KSI-PIY-04"
     },
     {
-      "ksi_id": "KSI-CMT-02",
+      "ksi_id": "KSI-CMT-RMV",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No rule defined for this KSI",
@@ -1140,7 +1196,8 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-04T02:27:49Z",
       "remediation_commit": "ef30886b4d62c35e14a4ec9317b9ae81826a14c8",
-      "duration_hours": 59.63
+      "duration_hours": 59.63,
+      "legacy_ksi_id": "KSI-CMT-02"
     },
     {
       "ksi_id": "KSI-SVC-03",
@@ -1152,7 +1209,9 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-04T02:27:49Z",
       "remediation_commit": "ef30886b4d62c35e14a4ec9317b9ae81826a14c8",
-      "duration_hours": 25.36
+      "duration_hours": 25.36,
+      "legacy_ksi_id": "KSI-SVC-03",
+      "retired_pre_cr26": true
     },
     {
       "ksi_id": "KSI-TPR-02",
@@ -1164,10 +1223,12 @@
       "requirement": "A secure cloud service offering will understand, monitor, and manage supply chain risks from third-party information resources.",
       "remediated_at": "2025-06-04T02:27:49Z",
       "remediation_commit": "ef30886b4d62c35e14a4ec9317b9ae81826a14c8",
-      "duration_hours": 59.63
+      "duration_hours": 59.63,
+      "legacy_ksi_id": "KSI-TPR-02",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-SVC-05",
+      "ksi_id": "KSI-SVC-VRI",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No DRT access role found",
@@ -1176,10 +1237,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-04T02:27:49Z",
       "remediation_commit": "ef30886b4d62c35e14a4ec9317b9ae81826a14c8",
-      "duration_hours": 59.63
+      "duration_hours": 59.63,
+      "legacy_ksi_id": "KSI-SVC-05"
     },
     {
-      "ksi_id": "KSI-RPL-02",
+      "ksi_id": "KSI-RPL-ARP",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No recovery points found",
@@ -1188,10 +1250,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-04T02:27:49Z",
       "remediation_commit": "ef30886b4d62c35e14a4ec9317b9ae81826a14c8",
-      "duration_hours": 59.63
+      "duration_hours": 59.63,
+      "legacy_ksi_id": "KSI-RPL-02"
     },
     {
-      "ksi_id": "KSI-SVC-06",
+      "ksi_id": "KSI-SVC-ASM",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No key rotation status",
@@ -1200,10 +1263,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-04T02:27:49Z",
       "remediation_commit": "ef30886b4d62c35e14a4ec9317b9ae81826a14c8",
-      "duration_hours": 59.63
+      "duration_hours": 59.63,
+      "legacy_ksi_id": "KSI-SVC-06"
     },
     {
-      "ksi_id": "KSI-INR-03",
+      "ksi_id": "KSI-INR-AAR",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No Inspector findings found",
@@ -1212,7 +1276,8 @@
       "requirement": "A secure cloud service offering will document, report, and analyze security incidents to ensure regulatory compliance and continuous security improvement.",
       "remediated_at": "2025-06-04T15:58:32Z",
       "remediation_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
-      "duration_hours": 73.14
+      "duration_hours": 73.14,
+      "legacy_ksi_id": "KSI-INR-03"
     },
     {
       "ksi_id": "KSI-TPR-01",
@@ -1224,10 +1289,12 @@
       "requirement": "A secure cloud service offering will understand, monitor, and manage supply chain risks from third-party information resources.",
       "remediated_at": "2025-06-04T15:58:32Z",
       "remediation_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
-      "duration_hours": 73.14
+      "duration_hours": 73.14,
+      "legacy_ksi_id": "KSI-TPR-01",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-CNA-02",
+      "ksi_id": "KSI-CNA-MAT",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "No subnets found \u2014 cannot evaluate segmentation",
@@ -1236,7 +1303,8 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-04T23:52:48Z",
       "remediation_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
-      "duration_hours": 7.9
+      "duration_hours": 7.9,
+      "legacy_ksi_id": "KSI-CNA-02"
     },
     {
       "ksi_id": "KSI-SVC-07",
@@ -1248,10 +1316,12 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-04T23:52:48Z",
       "remediation_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
-      "duration_hours": 81.05
+      "duration_hours": 81.05,
+      "legacy_ksi_id": "KSI-SVC-07",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-IAM-01",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2025-06-03T06:01:16Z",
       "failed_commit": "ad13894e14a4e819629942ec77243f598a02f964",
       "reason": "No check mfa enforcement (Users) found",
@@ -1260,10 +1330,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-04T23:52:48Z",
       "remediation_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
-      "duration_hours": 41.86
+      "duration_hours": 41.86,
+      "legacy_ksi_id": "KSI-IAM-01"
     },
     {
-      "ksi_id": "KSI-PIY-03",
+      "ksi_id": "KSI-PIY-RVD",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No Trusted Advisor checks found",
@@ -1272,10 +1343,11 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-04T23:52:48Z",
       "remediation_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
-      "duration_hours": 81.05
+      "duration_hours": 81.05,
+      "legacy_ksi_id": "KSI-PIY-03"
     },
     {
-      "ksi_id": "KSI-SVC-01",
+      "ksi_id": "KSI-SVC-EIS",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No web ACLs found",
@@ -1284,10 +1356,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-04T23:52:48Z",
       "remediation_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
-      "duration_hours": 81.05
+      "duration_hours": 81.05,
+      "legacy_ksi_id": "KSI-SVC-01"
     },
     {
-      "ksi_id": "KSI-PIY-06",
+      "ksi_id": "KSI-PIY-RIS",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "No IAM user policies found (AttachedPolicies is empty)",
@@ -1296,10 +1369,11 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-04T23:52:48Z",
       "remediation_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
-      "duration_hours": 7.9
+      "duration_hours": 7.9,
+      "legacy_ksi_id": "KSI-PIY-06"
     },
     {
-      "ksi_id": "KSI-CMT-04",
+      "ksi_id": "KSI-CMT-RVP",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No rule defined for this KSI",
@@ -1308,7 +1382,8 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-04T23:52:48Z",
       "remediation_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
-      "duration_hours": 81.05
+      "duration_hours": 81.05,
+      "legacy_ksi_id": "KSI-CMT-04"
     },
     {
       "ksi_id": "KSI-MLA-03",
@@ -1320,10 +1395,12 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-04T23:52:48Z",
       "remediation_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
-      "duration_hours": 81.05
+      "duration_hours": 81.05,
+      "legacy_ksi_id": "KSI-MLA-03",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-SVC-04",
+      "ksi_id": "KSI-SVC-ACM",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No configuration recorder statuses found",
@@ -1332,10 +1409,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-04T23:52:48Z",
       "remediation_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
-      "duration_hours": 81.05
+      "duration_hours": 81.05,
+      "legacy_ksi_id": "KSI-SVC-04"
     },
     {
-      "ksi_id": "KSI-PIY-04",
+      "ksi_id": "KSI-PIY-RSD",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "Rule error: name 'os' is not defined",
@@ -1344,10 +1422,11 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-04T23:52:48Z",
       "remediation_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
-      "duration_hours": 7.9
+      "duration_hours": 7.9,
+      "legacy_ksi_id": "KSI-PIY-04"
     },
     {
-      "ksi_id": "KSI-CNA-04",
+      "ksi_id": "KSI-CNA-DFP",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No EC2 reservations found",
@@ -1356,10 +1435,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-04T23:52:48Z",
       "remediation_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
-      "duration_hours": 81.05
+      "duration_hours": 81.05,
+      "legacy_ksi_id": "KSI-CNA-04"
     },
     {
-      "ksi_id": "KSI-CED-02",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-06-01T10:26:40Z",
       "failed_commit": "8e04c3d125f5084586d07799a45120bb85d0d930",
       "reason": "No relevant data found",
@@ -1368,7 +1448,8 @@
       "requirement": "A secure cloud service provider will continuously educate their employees on cybersecurity measures, testing them regularly to ensure their knowledge is satisfactory.",
       "remediated_at": "2025-06-04T23:52:48Z",
       "remediation_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
-      "duration_hours": 85.44
+      "duration_hours": 85.44,
+      "legacy_ksi_id": "KSI-CED-02"
     },
     {
       "ksi_id": "KSI-MLA-04",
@@ -1380,7 +1461,9 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-04T23:52:48Z",
       "remediation_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
-      "duration_hours": 81.05
+      "duration_hours": 81.05,
+      "legacy_ksi_id": "KSI-MLA-04",
+      "retired_pre_cr26": true
     },
     {
       "ksi_id": "KSI-PIY-07",
@@ -1392,7 +1475,9 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-04T23:52:48Z",
       "remediation_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
-      "duration_hours": 81.05
+      "duration_hours": 81.05,
+      "legacy_ksi_id": "KSI-PIY-07",
+      "retired_pre_cr26": true
     },
     {
       "ksi_id": "KSI-CMT-05",
@@ -1404,10 +1489,12 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-04T23:52:48Z",
       "remediation_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
-      "duration_hours": 81.05
+      "duration_hours": 81.05,
+      "legacy_ksi_id": "KSI-CMT-05",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-CNA-01",
+      "ksi_id": "KSI-CNA-RNT",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "No security groups returned",
@@ -1416,10 +1503,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-CNA-01"
     },
     {
-      "ksi_id": "KSI-CED-01",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "Rule error: name 'os' is not defined",
@@ -1428,10 +1516,11 @@
       "requirement": "A secure cloud service provider will continuously educate their employees on cybersecurity measures, testing them regularly to ensure their knowledge is satisfactory.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-CED-01"
     },
     {
-      "ksi_id": "KSI-CMT-01",
+      "ksi_id": "KSI-CMT-LMC",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No rule defined for this KSI",
@@ -1440,10 +1529,11 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 81.94
+      "duration_hours": 81.94,
+      "legacy_ksi_id": "KSI-CMT-01"
     },
     {
-      "ksi_id": "KSI-MLA-02",
+      "ksi_id": "KSI-MLA-RVL",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "No CloudTrail trails found",
@@ -1452,10 +1542,11 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-MLA-02"
     },
     {
-      "ksi_id": "KSI-CNA-07",
+      "ksi_id": "KSI-CNA-IBP",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No Well-Architected workloads found",
@@ -1464,10 +1555,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 81.94
+      "duration_hours": 81.94,
+      "legacy_ksi_id": "KSI-CNA-07"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "No backup plans found (BackupPlansList empty)",
@@ -1476,7 +1568,8 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
       "ksi_id": "KSI-MLA-06",
@@ -1488,10 +1581,12 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-MLA-06",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-TPR-04",
+      "ksi_id": "KSI-SCR-MON",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "Rule error: name 'os' is not defined",
@@ -1500,10 +1595,11 @@
       "requirement": "A secure cloud service offering will understand, monitor, and manage supply chain risks from third-party information resources.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-TPR-04"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "No Security Hub findings related to past incidents found (empty Findings list)",
@@ -1512,10 +1608,11 @@
       "requirement": "A secure cloud service offering will document, report, and analyze security incidents to ensure regulatory compliance and continuous security improvement.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "No backup jobs found (BackupJobs list empty)",
@@ -1524,7 +1621,8 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
       "ksi_id": "KSI-PIY-02",
@@ -1536,10 +1634,12 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-PIY-02",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-CNA-06",
+      "ksi_id": "KSI-CNA-OFA",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "No check ha routing (RouteTables) found",
@@ -1548,10 +1648,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-CNA-06"
     },
     {
-      "ksi_id": "KSI-CMT-02",
+      "ksi_id": "KSI-CMT-RMV",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "No active StackSets found \u2014 cannot confirm redeployment model for infrastructure changes",
@@ -1560,7 +1661,8 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-CMT-02"
     },
     {
       "ksi_id": "KSI-SVC-03",
@@ -1572,10 +1674,12 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-SVC-03",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-SVC-05",
+      "ksi_id": "KSI-SVC-VRI",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "No AMIs found \u2014 unable to confirm cryptographic enforcement of system image integrity",
@@ -1584,10 +1688,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-SVC-05"
     },
     {
-      "ksi_id": "KSI-RPL-02",
+      "ksi_id": "KSI-RPL-ARP",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "No backup plans found \u2014 unable to confirm backup targets",
@@ -1596,10 +1701,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-RPL-02"
     },
     {
-      "ksi_id": "KSI-SVC-06",
+      "ksi_id": "KSI-SVC-ASM",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "No KMS keys found \u2014 cannot confirm key lifecycle management",
@@ -1608,10 +1714,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-SVC-06"
     },
     {
-      "ksi_id": "KSI-INR-01",
+      "ksi_id": "KSI-INR-RIR",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No SecurityHub insights found",
@@ -1620,10 +1727,11 @@
       "requirement": "A secure cloud service offering will document, report, and analyze security incidents to ensure regulatory compliance and continuous security improvement.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 81.94
+      "duration_hours": 81.94,
+      "legacy_ksi_id": "KSI-INR-01"
     },
     {
-      "ksi_id": "KSI-IAM-02",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "No check auth models (Users) found",
@@ -1632,10 +1740,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 8.8
+      "duration_hours": 8.8,
+      "legacy_ksi_id": "KSI-IAM-02"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-06-03T01:06:31Z",
       "failed_commit": "046413fbfc5b70b6ff327167ee064e8c0ccb7e2e",
       "reason": "No backup jobs found",
@@ -1644,10 +1753,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 47.67
+      "duration_hours": 47.67,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-IAM-03",
+      "ksi_id": "KSI-IAM-SNU",
       "failed_at": "2025-06-03T01:06:31Z",
       "failed_commit": "046413fbfc5b70b6ff327167ee064e8c0ccb7e2e",
       "reason": "No IAM roles found",
@@ -1656,10 +1766,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 47.67
+      "duration_hours": 47.67,
+      "legacy_ksi_id": "KSI-IAM-03"
     },
     {
-      "ksi_id": "KSI-MLA-01",
+      "ksi_id": "KSI-MLA-OSM",
       "failed_at": "2025-06-03T06:01:16Z",
       "failed_commit": "ad13894e14a4e819629942ec77243f598a02f964",
       "reason": "No siem visibility (Items) found",
@@ -1668,10 +1779,11 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-05T00:46:27Z",
       "remediation_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
-      "duration_hours": 42.75
+      "duration_hours": 42.75,
+      "legacy_ksi_id": "KSI-MLA-01"
     },
     {
-      "ksi_id": "KSI-SVC-01",
+      "ksi_id": "KSI-SVC-EIS",
       "failed_at": "2025-06-05T00:46:27Z",
       "failed_commit": "a52107a44bce5752ca019fcc53be0fb33587bc48",
       "reason": "Unexpected structure or missing InstanceInformationList in output.",
@@ -1680,10 +1792,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-05T03:14:02Z",
       "remediation_commit": "3915bd1787c40f71d36575dc4278f93f17cbed51",
-      "duration_hours": 2.46
+      "duration_hours": 2.46,
+      "legacy_ksi_id": "KSI-SVC-01"
     },
     {
-      "ksi_id": "KSI-IAM-04",
+      "ksi_id": "KSI-IAM-JIT",
       "failed_at": "2025-06-03T06:01:16Z",
       "failed_commit": "ad13894e14a4e819629942ec77243f598a02f964",
       "reason": "No review policies (Items) found",
@@ -1692,10 +1805,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-05T03:14:02Z",
       "remediation_commit": "3915bd1787c40f71d36575dc4278f93f17cbed51",
-      "duration_hours": 45.21
+      "duration_hours": 45.21,
+      "legacy_ksi_id": "KSI-IAM-04"
     },
     {
-      "ksi_id": "KSI-CED-01",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-06-05T05:01:53Z",
       "failed_commit": "6a450dfe3a80a7bdf94fe8db61d8aa14ccc65092",
       "reason": "Rule error: 'list' object has no attribute 'get'",
@@ -1704,10 +1818,11 @@
       "requirement": "A secure cloud service provider will continuously educate their employees on cybersecurity measures, testing them regularly to ensure their knowledge is satisfactory.",
       "remediated_at": "2025-06-05T07:51:26Z",
       "remediation_commit": "dce97d2e87502df56a0a725af07152bc83d9ef5b",
-      "duration_hours": 2.83
+      "duration_hours": 2.83,
+      "legacy_ksi_id": "KSI-CED-01"
     },
     {
-      "ksi_id": "KSI-CMT-01",
+      "ksi_id": "KSI-CMT-LMC",
       "failed_at": "2025-06-05T05:01:53Z",
       "failed_commit": "6a450dfe3a80a7bdf94fe8db61d8aa14ccc65092",
       "reason": "Rule error: 'list' object has no attribute 'get'",
@@ -1716,7 +1831,8 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-05T07:51:26Z",
       "remediation_commit": "dce97d2e87502df56a0a725af07152bc83d9ef5b",
-      "duration_hours": 2.83
+      "duration_hours": 2.83,
+      "legacy_ksi_id": "KSI-CMT-01"
     },
     {
       "ksi_id": "KSI-PIY-02",
@@ -1728,7 +1844,9 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-05T07:51:26Z",
       "remediation_commit": "dce97d2e87502df56a0a725af07152bc83d9ef5b",
-      "duration_hours": 2.83
+      "duration_hours": 2.83,
+      "legacy_ksi_id": "KSI-PIY-02",
+      "retired_pre_cr26": true
     },
     {
       "ksi_id": "KSI-MLA-03",
@@ -1740,10 +1858,12 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-05T07:51:26Z",
       "remediation_commit": "dce97d2e87502df56a0a725af07152bc83d9ef5b",
-      "duration_hours": 2.83
+      "duration_hours": 2.83,
+      "legacy_ksi_id": "KSI-MLA-03",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-CNA-06",
+      "ksi_id": "KSI-CNA-OFA",
       "failed_at": "2025-06-05T05:01:53Z",
       "failed_commit": "6a450dfe3a80a7bdf94fe8db61d8aa14ccc65092",
       "reason": "Rule error: 'list' object has no attribute 'get'",
@@ -1752,10 +1872,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-05T07:51:26Z",
       "remediation_commit": "dce97d2e87502df56a0a725af07152bc83d9ef5b",
-      "duration_hours": 2.83
+      "duration_hours": 2.83,
+      "legacy_ksi_id": "KSI-CNA-06"
     },
     {
-      "ksi_id": "KSI-PIY-01",
+      "ksi_id": "KSI-PIY-GIV",
       "failed_at": "2025-06-05T05:01:53Z",
       "failed_commit": "6a450dfe3a80a7bdf94fe8db61d8aa14ccc65092",
       "reason": "Rule error: 'list' object has no attribute 'get'",
@@ -1764,10 +1885,11 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-05T07:51:26Z",
       "remediation_commit": "dce97d2e87502df56a0a725af07152bc83d9ef5b",
-      "duration_hours": 2.83
+      "duration_hours": 2.83,
+      "legacy_ksi_id": "KSI-PIY-01"
     },
     {
-      "ksi_id": "KSI-CNA-04",
+      "ksi_id": "KSI-CNA-DFP",
       "failed_at": "2025-06-05T05:01:53Z",
       "failed_commit": "6a450dfe3a80a7bdf94fe8db61d8aa14ccc65092",
       "reason": "Rule error: 'list' object has no attribute 'get'",
@@ -1776,7 +1898,8 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-05T07:51:26Z",
       "remediation_commit": "dce97d2e87502df56a0a725af07152bc83d9ef5b",
-      "duration_hours": 2.83
+      "duration_hours": 2.83,
+      "legacy_ksi_id": "KSI-CNA-04"
     },
     {
       "ksi_id": "KSI-TPR-02",
@@ -1788,10 +1911,12 @@
       "requirement": "A secure cloud service offering will understand, monitor, and manage supply chain risks from third-party information resources.",
       "remediated_at": "2025-06-05T07:51:26Z",
       "remediation_commit": "dce97d2e87502df56a0a725af07152bc83d9ef5b",
-      "duration_hours": 2.83
+      "duration_hours": 2.83,
+      "legacy_ksi_id": "KSI-TPR-02",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-RPL-02",
+      "ksi_id": "KSI-RPL-ARP",
       "failed_at": "2025-06-05T05:01:53Z",
       "failed_commit": "6a450dfe3a80a7bdf94fe8db61d8aa14ccc65092",
       "reason": "Rule error: 'list' object has no attribute 'get'",
@@ -1800,10 +1925,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-05T07:51:26Z",
       "remediation_commit": "dce97d2e87502df56a0a725af07152bc83d9ef5b",
-      "duration_hours": 2.83
+      "duration_hours": 2.83,
+      "legacy_ksi_id": "KSI-RPL-02"
     },
     {
-      "ksi_id": "KSI-IAM-02",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2025-06-05T05:01:53Z",
       "failed_commit": "6a450dfe3a80a7bdf94fe8db61d8aa14ccc65092",
       "reason": "Rule error: 'list' object has no attribute 'get'",
@@ -1812,10 +1938,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-05T07:51:26Z",
       "remediation_commit": "dce97d2e87502df56a0a725af07152bc83d9ef5b",
-      "duration_hours": 2.83
+      "duration_hours": 2.83,
+      "legacy_ksi_id": "KSI-IAM-02"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-06-05T05:01:53Z",
       "failed_commit": "6a450dfe3a80a7bdf94fe8db61d8aa14ccc65092",
       "reason": "Rule error: 'list' object has no attribute 'get'",
@@ -1824,10 +1951,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-05T07:51:26Z",
       "remediation_commit": "dce97d2e87502df56a0a725af07152bc83d9ef5b",
-      "duration_hours": 2.83
+      "duration_hours": 2.83,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-IAM-03",
+      "ksi_id": "KSI-IAM-SNU",
       "failed_at": "2025-06-05T05:01:53Z",
       "failed_commit": "6a450dfe3a80a7bdf94fe8db61d8aa14ccc65092",
       "reason": "Rule error: 'list' object has no attribute 'get'",
@@ -1836,10 +1964,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-05T07:51:26Z",
       "remediation_commit": "dce97d2e87502df56a0a725af07152bc83d9ef5b",
-      "duration_hours": 2.83
+      "duration_hours": 2.83,
+      "legacy_ksi_id": "KSI-IAM-03"
     },
     {
-      "ksi_id": "KSI-MLA-01",
+      "ksi_id": "KSI-MLA-OSM",
       "failed_at": "2025-06-05T05:01:53Z",
       "failed_commit": "6a450dfe3a80a7bdf94fe8db61d8aa14ccc65092",
       "reason": "Rule error: 'list' object has no attribute 'get'",
@@ -1848,10 +1977,11 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-05T07:51:26Z",
       "remediation_commit": "dce97d2e87502df56a0a725af07152bc83d9ef5b",
-      "duration_hours": 2.83
+      "duration_hours": 2.83,
+      "legacy_ksi_id": "KSI-MLA-01"
     },
     {
-      "ksi_id": "KSI-CNA-02",
+      "ksi_id": "KSI-CNA-MAT",
       "failed_at": "2025-06-05T05:01:53Z",
       "failed_commit": "6a450dfe3a80a7bdf94fe8db61d8aa14ccc65092",
       "reason": "Rule error: 'list' object has no attribute 'get'",
@@ -1860,10 +1990,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-05T08:01:49Z",
       "remediation_commit": "d58baa18e768e396a3fcc309402aa6896c1b1497",
-      "duration_hours": 3.0
+      "duration_hours": 3.0,
+      "legacy_ksi_id": "KSI-CNA-02"
     },
     {
-      "ksi_id": "KSI-CNA-01",
+      "ksi_id": "KSI-CNA-RNT",
       "failed_at": "2025-06-05T03:40:19Z",
       "failed_commit": "0f19dc3963dcb209d865c90f7b3dd5334d6839b3",
       "reason": "Rule error: 'str' object has no attribute 'get'",
@@ -1872,10 +2003,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-05T08:01:49Z",
       "remediation_commit": "d58baa18e768e396a3fcc309402aa6896c1b1497",
-      "duration_hours": 4.36
+      "duration_hours": 4.36,
+      "legacy_ksi_id": "KSI-CNA-01"
     },
     {
-      "ksi_id": "KSI-MLA-02",
+      "ksi_id": "KSI-MLA-RVL",
       "failed_at": "2025-06-05T05:01:53Z",
       "failed_commit": "6a450dfe3a80a7bdf94fe8db61d8aa14ccc65092",
       "reason": "Rule error: 'list' object has no attribute 'get'",
@@ -1884,10 +2016,11 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-05T08:01:49Z",
       "remediation_commit": "d58baa18e768e396a3fcc309402aa6896c1b1497",
-      "duration_hours": 3.0
+      "duration_hours": 3.0,
+      "legacy_ksi_id": "KSI-MLA-02"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-06-05T05:01:53Z",
       "failed_commit": "6a450dfe3a80a7bdf94fe8db61d8aa14ccc65092",
       "reason": "Rule error: 'list' object has no attribute 'get'",
@@ -1896,10 +2029,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-05T08:01:49Z",
       "remediation_commit": "d58baa18e768e396a3fcc309402aa6896c1b1497",
-      "duration_hours": 3.0
+      "duration_hours": 3.0,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-IAM-04",
+      "ksi_id": "KSI-IAM-JIT",
       "failed_at": "2025-06-05T05:01:53Z",
       "failed_commit": "6a450dfe3a80a7bdf94fe8db61d8aa14ccc65092",
       "reason": "Rule error: 'list' object has no attribute 'get'",
@@ -1908,10 +2042,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-05T08:01:49Z",
       "remediation_commit": "d58baa18e768e396a3fcc309402aa6896c1b1497",
-      "duration_hours": 3.0
+      "duration_hours": 3.0,
+      "legacy_ksi_id": "KSI-IAM-04"
     },
     {
-      "ksi_id": "KSI-CNA-07",
+      "ksi_id": "KSI-CNA-IBP",
       "failed_at": "2025-06-05T21:22:21Z",
       "failed_commit": "3654a709f4222bd161acb35b1491df1310e308fa",
       "reason": "Rule error: 'list' object has no attribute 'get'",
@@ -1920,7 +2055,8 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-05T23:10:51Z",
       "remediation_commit": "c2fa2d54be386e2af0837908dc5ddcd87670b379",
-      "duration_hours": 1.81
+      "duration_hours": 1.81,
+      "legacy_ksi_id": "KSI-CNA-07"
     },
     {
       "ksi_id": "KSI-MLA-06",
@@ -1932,10 +2068,12 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-05T23:10:51Z",
       "remediation_commit": "c2fa2d54be386e2af0837908dc5ddcd87670b379",
-      "duration_hours": 1.81
+      "duration_hours": 1.81,
+      "legacy_ksi_id": "KSI-MLA-06",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-TPR-04",
+      "ksi_id": "KSI-SCR-MON",
       "failed_at": "2025-06-05T21:22:21Z",
       "failed_commit": "3654a709f4222bd161acb35b1491df1310e308fa",
       "reason": "No upstream alerting findings and no static attestation found.",
@@ -1944,10 +2082,11 @@
       "requirement": "A secure cloud service offering will understand, monitor, and manage supply chain risks from third-party information resources.",
       "remediated_at": "2025-06-05T23:10:51Z",
       "remediation_commit": "c2fa2d54be386e2af0837908dc5ddcd87670b379",
-      "duration_hours": 1.81
+      "duration_hours": 1.81,
+      "legacy_ksi_id": "KSI-TPR-04"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2025-06-05T21:22:21Z",
       "failed_commit": "3654a709f4222bd161acb35b1491df1310e308fa",
       "reason": "No Security Hub findings related to past incidents found (empty Findings list)",
@@ -1956,10 +2095,11 @@
       "requirement": "A secure cloud service offering will document, report, and analyze security incidents to ensure regulatory compliance and continuous security improvement.",
       "remediated_at": "2025-06-05T23:10:51Z",
       "remediation_commit": "c2fa2d54be386e2af0837908dc5ddcd87670b379",
-      "duration_hours": 1.81
+      "duration_hours": 1.81,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2025-06-05T21:22:21Z",
       "failed_commit": "3654a709f4222bd161acb35b1491df1310e308fa",
       "reason": "No backup jobs found (BackupJobs list empty)",
@@ -1968,10 +2108,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-05T23:10:51Z",
       "remediation_commit": "c2fa2d54be386e2af0837908dc5ddcd87670b379",
-      "duration_hours": 1.81
+      "duration_hours": 1.81,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
-      "ksi_id": "KSI-CMT-02",
+      "ksi_id": "KSI-CMT-RMV",
       "failed_at": "2025-06-05T21:22:21Z",
       "failed_commit": "3654a709f4222bd161acb35b1491df1310e308fa",
       "reason": "No active StackSets found \u2014 cannot confirm redeployment model for infrastructure changes",
@@ -1980,7 +2121,8 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-05T23:10:51Z",
       "remediation_commit": "c2fa2d54be386e2af0837908dc5ddcd87670b379",
-      "duration_hours": 1.81
+      "duration_hours": 1.81,
+      "legacy_ksi_id": "KSI-CMT-02"
     },
     {
       "ksi_id": "KSI-SVC-03",
@@ -1992,10 +2134,12 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-05T23:10:51Z",
       "remediation_commit": "c2fa2d54be386e2af0837908dc5ddcd87670b379",
-      "duration_hours": 1.81
+      "duration_hours": 1.81,
+      "legacy_ksi_id": "KSI-SVC-03",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-SVC-05",
+      "ksi_id": "KSI-SVC-VRI",
       "failed_at": "2025-06-05T21:22:21Z",
       "failed_commit": "3654a709f4222bd161acb35b1491df1310e308fa",
       "reason": "No AMIs found \u2014 unable to confirm cryptographic enforcement of system image integrity",
@@ -2004,10 +2148,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-05T23:10:51Z",
       "remediation_commit": "c2fa2d54be386e2af0837908dc5ddcd87670b379",
-      "duration_hours": 1.81
+      "duration_hours": 1.81,
+      "legacy_ksi_id": "KSI-SVC-05"
     },
     {
-      "ksi_id": "KSI-SVC-06",
+      "ksi_id": "KSI-SVC-ASM",
       "failed_at": "2025-06-05T21:22:21Z",
       "failed_commit": "3654a709f4222bd161acb35b1491df1310e308fa",
       "reason": "No KMS keys found \u2014 cannot confirm key lifecycle management",
@@ -2016,10 +2161,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-05T23:10:51Z",
       "remediation_commit": "c2fa2d54be386e2af0837908dc5ddcd87670b379",
-      "duration_hours": 1.81
+      "duration_hours": 1.81,
+      "legacy_ksi_id": "KSI-SVC-06"
     },
     {
-      "ksi_id": "KSI-INR-01",
+      "ksi_id": "KSI-INR-RIR",
       "failed_at": "2025-06-05T21:22:21Z",
       "failed_commit": "3654a709f4222bd161acb35b1491df1310e308fa",
       "reason": "No SecurityHub findings found \u2014 incident reporting may not be active",
@@ -2028,10 +2174,11 @@
       "requirement": "A secure cloud service offering will document, report, and analyze security incidents to ensure regulatory compliance and continuous security improvement.",
       "remediated_at": "2025-06-05T23:10:51Z",
       "remediation_commit": "c2fa2d54be386e2af0837908dc5ddcd87670b379",
-      "duration_hours": 1.81
+      "duration_hours": 1.81,
+      "legacy_ksi_id": "KSI-INR-01"
     },
     {
-      "ksi_id": "KSI-IAM-02",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2025-06-05T23:10:51Z",
       "failed_commit": "c2fa2d54be386e2af0837908dc5ddcd87670b379",
       "reason": "No users found \u2014 identity model appears empty",
@@ -2040,10 +2187,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-05T23:25:41Z",
       "remediation_commit": "4d11f52ba2412a4477f79259775ebaad4050aa89",
-      "duration_hours": 0.25
+      "duration_hours": 0.25,
+      "legacy_ksi_id": "KSI-IAM-02"
     },
     {
-      "ksi_id": "KSI-IAM-01",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2025-06-05T23:49:48Z",
       "failed_commit": "b23b62e26d5bf04642fcf9a315790fa340e27e7f",
       "reason": "Rule error: 'str' object has no attribute 'get'",
@@ -2052,7 +2200,8 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-06T03:48:06.017208Z",
       "remediation_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
-      "duration_hours": 3.97
+      "duration_hours": 3.97,
+      "legacy_ksi_id": "KSI-IAM-01"
     },
     {
       "ksi_id": "KSI-MLA-04",
@@ -2064,7 +2213,9 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-06T03:48:06.017208Z",
       "remediation_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
-      "duration_hours": 3.97
+      "duration_hours": 3.97,
+      "legacy_ksi_id": "KSI-MLA-04",
+      "retired_pre_cr26": true
     },
     {
       "ksi_id": "KSI-SVC-03",
@@ -2076,10 +2227,12 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-06T04:21:09.354677Z",
       "remediation_commit": "400485341a877700e30c29f7d2815620d323dc01",
-      "duration_hours": 0.55
+      "duration_hours": 0.55,
+      "legacy_ksi_id": "KSI-SVC-03",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-IAM-04",
+      "ksi_id": "KSI-IAM-JIT",
       "failed_at": "2025-06-05T23:49:48Z",
       "failed_commit": "b23b62e26d5bf04642fcf9a315790fa340e27e7f",
       "reason": "Unexpected output format",
@@ -2088,10 +2241,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-06T04:21:09.354677Z",
       "remediation_commit": "400485341a877700e30c29f7d2815620d323dc01",
-      "duration_hours": 4.52
+      "duration_hours": 4.52,
+      "legacy_ksi_id": "KSI-IAM-04"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "No backup plans found \u2014 unable to verify recovery posture definition",
@@ -2100,10 +2254,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-06T04:21:09.354677Z",
       "remediation_commit": "400485341a877700e30c29f7d2815620d323dc01",
-      "duration_hours": 0.55
+      "duration_hours": 0.55,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-MLA-01",
+      "ksi_id": "KSI-MLA-OSM",
       "failed_at": "2025-06-05T23:49:48Z",
       "failed_commit": "b23b62e26d5bf04642fcf9a315790fa340e27e7f",
       "reason": "No CloudWatch log groups found \u2014 SIEM visibility not verifiable",
@@ -2112,7 +2267,8 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-06T04:21:09.354677Z",
       "remediation_commit": "400485341a877700e30c29f7d2815620d323dc01",
-      "duration_hours": 4.52
+      "duration_hours": 4.52,
+      "legacy_ksi_id": "KSI-MLA-01"
     },
     {
       "ksi_id": "KSI-SVC-07",
@@ -2124,10 +2280,12 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-06T05:52:21.613477Z",
       "remediation_commit": "ef1e28289349c5821d290c8283f77e26be954bf6",
-      "duration_hours": 1.52
+      "duration_hours": 1.52,
+      "legacy_ksi_id": "KSI-SVC-07",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-CNA-01",
+      "ksi_id": "KSI-CNA-RNT",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "No security groups returned",
@@ -2136,10 +2294,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-06T05:52:21.613477Z",
       "remediation_commit": "ef1e28289349c5821d290c8283f77e26be954bf6",
-      "duration_hours": 2.07
+      "duration_hours": 2.07,
+      "legacy_ksi_id": "KSI-CNA-01"
     },
     {
-      "ksi_id": "KSI-CED-01",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "No IAM users or static training evidence found",
@@ -2148,10 +2307,11 @@
       "requirement": "A secure cloud service provider will continuously educate their employees on cybersecurity measures, testing them regularly to ensure their knowledge is satisfactory.",
       "remediated_at": "2025-06-06T05:52:21.613477Z",
       "remediation_commit": "ef1e28289349c5821d290c8283f77e26be954bf6",
-      "duration_hours": 2.07
+      "duration_hours": 2.07,
+      "legacy_ksi_id": "KSI-CED-01"
     },
     {
-      "ksi_id": "KSI-SVC-01",
+      "ksi_id": "KSI-SVC-EIS",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "Unexpected structure or missing InstanceInformationList in output.",
@@ -2160,7 +2320,8 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-06T05:52:21.613477Z",
       "remediation_commit": "ef1e28289349c5821d290c8283f77e26be954bf6",
-      "duration_hours": 2.07
+      "duration_hours": 2.07,
+      "legacy_ksi_id": "KSI-SVC-01"
     },
     {
       "ksi_id": "KSI-MLA-06",
@@ -2172,10 +2333,12 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-06T05:52:21.613477Z",
       "remediation_commit": "ef1e28289349c5821d290c8283f77e26be954bf6",
-      "duration_hours": 6.04
+      "duration_hours": 6.04,
+      "legacy_ksi_id": "KSI-MLA-06",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-PIY-01",
+      "ksi_id": "KSI-PIY-GIV",
       "failed_at": "2025-06-06T04:21:09.354677Z",
       "failed_commit": "400485341a877700e30c29f7d2815620d323dc01",
       "reason": "No comprehensive information resource inventory:  No AWS resource inventory data;  No manual asset inventory documentation found",
@@ -2184,10 +2347,11 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-06T05:52:21.613477Z",
       "remediation_commit": "ef1e28289349c5821d290c8283f77e26be954bf6",
-      "duration_hours": 1.52
+      "duration_hours": 1.52,
+      "legacy_ksi_id": "KSI-PIY-01"
     },
     {
-      "ksi_id": "KSI-CNA-04",
+      "ksi_id": "KSI-CNA-DFP",
       "failed_at": "2025-06-06T04:21:09.354677Z",
       "failed_commit": "400485341a877700e30c29f7d2815620d323dc01",
       "reason": "No Infrastructure as Code patterns found",
@@ -2196,10 +2360,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-06T05:52:21.613477Z",
       "remediation_commit": "ef1e28289349c5821d290c8283f77e26be954bf6",
-      "duration_hours": 1.52
+      "duration_hours": 1.52,
+      "legacy_ksi_id": "KSI-CNA-04"
     },
     {
-      "ksi_id": "KSI-CED-02",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-06-06T04:21:09.354677Z",
       "failed_commit": "400485341a877700e30c29f7d2815620d323dc01",
       "reason": "No rule defined for KSI-CED-02",
@@ -2208,10 +2373,11 @@
       "requirement": "A secure cloud service provider will continuously educate their employees on cybersecurity measures, testing them regularly to ensure their knowledge is satisfactory.",
       "remediated_at": "2025-06-06T05:52:21.613477Z",
       "remediation_commit": "ef1e28289349c5821d290c8283f77e26be954bf6",
-      "duration_hours": 1.52
+      "duration_hours": 1.52,
+      "legacy_ksi_id": "KSI-CED-02"
     },
     {
-      "ksi_id": "KSI-CMT-02",
+      "ksi_id": "KSI-CMT-RMV",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "No active StackSets found \u2014 cannot confirm redeployment model for infrastructure changes",
@@ -2220,10 +2386,11 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-06T05:52:21.613477Z",
       "remediation_commit": "ef1e28289349c5821d290c8283f77e26be954bf6",
-      "duration_hours": 2.07
+      "duration_hours": 2.07,
+      "legacy_ksi_id": "KSI-CMT-02"
     },
     {
-      "ksi_id": "KSI-SVC-05",
+      "ksi_id": "KSI-SVC-VRI",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "No AMIs found \u2014 unable to confirm cryptographic enforcement of system image integrity",
@@ -2232,10 +2399,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-06T05:52:21.613477Z",
       "remediation_commit": "ef1e28289349c5821d290c8283f77e26be954bf6",
-      "duration_hours": 2.07
+      "duration_hours": 2.07,
+      "legacy_ksi_id": "KSI-SVC-05"
     },
     {
-      "ksi_id": "KSI-SVC-02",
+      "ksi_id": "KSI-SVC-SIN",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No VPN connections found",
@@ -2244,10 +2412,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-06T05:52:21.613477Z",
       "remediation_commit": "ef1e28289349c5821d290c8283f77e26be954bf6",
-      "duration_hours": 111.04
+      "duration_hours": 111.04,
+      "legacy_ksi_id": "KSI-SVC-02"
     },
     {
-      "ksi_id": "KSI-IAM-05",
+      "ksi_id": "KSI-IAM-ELP",
       "failed_at": "2025-06-03T01:06:31Z",
       "failed_commit": "046413fbfc5b70b6ff327167ee064e8c0ccb7e2e",
       "reason": "No account authorization details found",
@@ -2256,10 +2425,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-06T05:52:21.613477Z",
       "remediation_commit": "ef1e28289349c5821d290c8283f77e26be954bf6",
-      "duration_hours": 76.76
+      "duration_hours": 76.76,
+      "legacy_ksi_id": "KSI-IAM-05"
     },
     {
-      "ksi_id": "KSI-CNA-03",
+      "ksi_id": "KSI-CNA-ULN",
       "failed_at": "2025-06-04T15:58:32Z",
       "failed_commit": "4eb5cafbb2e3d6b5f591d018b2f40d49ff7d6943",
       "reason": "No route tables found to evaluate",
@@ -2268,10 +2438,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-06T05:52:21.613477Z",
       "remediation_commit": "ef1e28289349c5821d290c8283f77e26be954bf6",
-      "duration_hours": 37.9
+      "duration_hours": 37.9,
+      "legacy_ksi_id": "KSI-CNA-03"
     },
     {
-      "ksi_id": "KSI-MLA-05",
+      "ksi_id": "KSI-MLA-EVC",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No config rules found",
@@ -2280,10 +2451,11 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-06T06:36:35.411474Z",
       "remediation_commit": "f4b72dea158eda93cc06460d23d14f505d4aaa88",
-      "duration_hours": 111.78
+      "duration_hours": 111.78,
+      "legacy_ksi_id": "KSI-MLA-05"
     },
     {
-      "ksi_id": "KSI-IAM-03",
+      "ksi_id": "KSI-IAM-SNU",
       "failed_at": "2025-06-05T23:49:48Z",
       "failed_commit": "b23b62e26d5bf04642fcf9a315790fa340e27e7f",
       "reason": "Unexpected output format",
@@ -2292,10 +2464,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-06T06:36:35.411474Z",
       "remediation_commit": "f4b72dea158eda93cc06460d23d14f505d4aaa88",
-      "duration_hours": 6.78
+      "duration_hours": 6.78,
+      "legacy_ksi_id": "KSI-IAM-03"
     },
     {
-      "ksi_id": "KSI-CNA-02",
+      "ksi_id": "KSI-CNA-MAT",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "No subnets found \u2014 cannot evaluate segmentation",
@@ -2304,10 +2477,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-06T06:57:45.614448Z",
       "remediation_commit": "44f60c96cbdb1b5b4cf1aff7f6045a3443a57c0b",
-      "duration_hours": 3.16
+      "duration_hours": 3.16,
+      "legacy_ksi_id": "KSI-CNA-02"
     },
     {
-      "ksi_id": "KSI-CMT-01",
+      "ksi_id": "KSI-CMT-LMC",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "No CloudTrail trails found \u2014 cannot verify config change monitoring",
@@ -2316,7 +2490,8 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-06T08:10:04.439076Z",
       "remediation_commit": "a5a4c51694feb123b8fd6998c2adcefaf41c3990",
-      "duration_hours": 4.37
+      "duration_hours": 4.37,
+      "legacy_ksi_id": "KSI-CMT-01"
     },
     {
       "ksi_id": "KSI-PIY-02",
@@ -2328,10 +2503,12 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-06T08:10:04.439076Z",
       "remediation_commit": "a5a4c51694feb123b8fd6998c2adcefaf41c3990",
-      "duration_hours": 4.37
+      "duration_hours": 4.37,
+      "legacy_ksi_id": "KSI-PIY-02",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-SVC-04",
+      "ksi_id": "KSI-SVC-ACM",
       "failed_at": "2025-06-06T04:21:09.354677Z",
       "failed_commit": "400485341a877700e30c29f7d2815620d323dc01",
       "reason": "No centralized configuration management found:",
@@ -2340,10 +2517,11 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-06T08:10:04.439076Z",
       "remediation_commit": "a5a4c51694feb123b8fd6998c2adcefaf41c3990",
-      "duration_hours": 3.82
+      "duration_hours": 3.82,
+      "legacy_ksi_id": "KSI-SVC-04"
     },
     {
-      "ksi_id": "KSI-CNA-06",
+      "ksi_id": "KSI-CNA-OFA",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "No route tables found for HA routing",
@@ -2352,10 +2530,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-06T08:10:04.439076Z",
       "remediation_commit": "a5a4c51694feb123b8fd6998c2adcefaf41c3990",
-      "duration_hours": 4.37
+      "duration_hours": 4.37,
+      "legacy_ksi_id": "KSI-CNA-06"
     },
     {
-      "ksi_id": "KSI-INR-01",
+      "ksi_id": "KSI-INR-RIR",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "No SecurityHub findings found \u2014 incident reporting may not be active",
@@ -2364,10 +2543,11 @@
       "requirement": "A secure cloud service offering will document, report, and analyze security incidents to ensure regulatory compliance and continuous security improvement.",
       "remediated_at": "2025-06-06T08:10:04.439076Z",
       "remediation_commit": "a5a4c51694feb123b8fd6998c2adcefaf41c3990",
-      "duration_hours": 4.37
+      "duration_hours": 4.37,
+      "legacy_ksi_id": "KSI-INR-01"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "No backup plans found (BackupPlansList empty)",
@@ -2376,10 +2556,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-06T08:21:01.725666Z",
       "remediation_commit": "637c83dbb92b7cb83f8e62ec13bd78c3344d87cb",
-      "duration_hours": 4.55
+      "duration_hours": 4.55,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "No backup jobs found (BackupJobs list empty)",
@@ -2388,7 +2569,8 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-06T08:29:51.564907Z",
       "remediation_commit": "aefdbcaf57ed70813683a0a61674cea8e6916f44",
-      "duration_hours": 4.7
+      "duration_hours": 4.7,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
       "ksi_id": "KSI-TPR-01",
@@ -2400,10 +2582,12 @@
       "requirement": "A secure cloud service offering will understand, monitor, and manage supply chain risks from third-party information resources.",
       "remediated_at": "2025-06-06T08:29:51.564907Z",
       "remediation_commit": "aefdbcaf57ed70813683a0a61674cea8e6916f44",
-      "duration_hours": 31.72
+      "duration_hours": 31.72,
+      "legacy_ksi_id": "KSI-TPR-01",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-RPL-02",
+      "ksi_id": "KSI-RPL-ARP",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "No backup plans found \u2014 unable to confirm backup targets",
@@ -2412,10 +2596,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-06T08:29:51.564907Z",
       "remediation_commit": "aefdbcaf57ed70813683a0a61674cea8e6916f44",
-      "duration_hours": 4.7
+      "duration_hours": 4.7,
+      "legacy_ksi_id": "KSI-RPL-02"
     },
     {
-      "ksi_id": "KSI-IAM-01",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2025-06-06T04:21:09.354677Z",
       "failed_commit": "400485341a877700e30c29f7d2815620d323dc01",
       "reason": "Only virtual MFA found (1 devices) - phishing-resistant MFA required",
@@ -2424,7 +2609,8 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-06T08:50:09.272386Z",
       "remediation_commit": "b5e21ad3beed167db4f61f7bd01b44be73dd6c49",
-      "duration_hours": 4.48
+      "duration_hours": 4.48,
+      "legacy_ksi_id": "KSI-IAM-01"
     },
     {
       "ksi_id": "KSI-MLA-04",
@@ -2436,10 +2622,12 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-06T09:01:03.468311Z",
       "remediation_commit": "a4faa9c7068ab3a9a7222cc73502296b5e7450b7",
-      "duration_hours": 4.67
+      "duration_hours": 4.67,
+      "legacy_ksi_id": "KSI-MLA-04",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-TPR-04",
+      "ksi_id": "KSI-SCR-MON",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "No upstream alerting findings and no static attestation found.",
@@ -2448,10 +2636,11 @@
       "requirement": "A secure cloud service offering will understand, monitor, and manage supply chain risks from third-party information resources.",
       "remediated_at": "2025-06-06T09:11:09.903447Z",
       "remediation_commit": "6c80de017bbbe399266204ba27828936ffb5dde7",
-      "duration_hours": 5.38
+      "duration_hours": 5.38,
+      "legacy_ksi_id": "KSI-TPR-04"
     },
     {
-      "ksi_id": "KSI-IAM-06",
+      "ksi_id": "KSI-IAM-SUS",
       "failed_at": "2025-06-04T23:52:48Z",
       "failed_commit": "23049388a17e31d995c2f1838a0db3c14321a42d",
       "reason": "Rule error: 'str' object has no attribute 'get'",
@@ -2460,10 +2649,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-06T09:29:28.505780Z",
       "remediation_commit": "3e72e2bcd6f75b2ff256560d2c4a4b9e0e19d83b",
-      "duration_hours": 33.61
+      "duration_hours": 33.61,
+      "legacy_ksi_id": "KSI-IAM-06"
     },
     {
-      "ksi_id": "KSI-MLA-02",
+      "ksi_id": "KSI-MLA-RVL",
       "failed_at": "2025-06-05T23:49:48Z",
       "failed_commit": "b23b62e26d5bf04642fcf9a315790fa340e27e7f",
       "reason": "No CloudTrail trails found",
@@ -2472,10 +2662,11 @@
       "requirement": "A secure cloud service offering will monitor, log, and audit all important events, activity, and changes.",
       "remediated_at": "2025-06-06T09:29:28.505780Z",
       "remediation_commit": "3e72e2bcd6f75b2ff256560d2c4a4b9e0e19d83b",
-      "duration_hours": 9.66
+      "duration_hours": 9.66,
+      "legacy_ksi_id": "KSI-MLA-02"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-06-06T09:55:00.645081Z",
       "failed_commit": "e5874406f940ac5e6e96fd9a28197cb32dcc101b",
       "reason": "No system backup implementation:  No AWS Backup plans found; \u2139 No EBS snapshots found (acceptable for low-impact if no EBS volumes)",
@@ -2484,10 +2675,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-06T10:20:01.029618Z",
       "remediation_commit": "6b741854a506177e58af0f9c80a87e8109479071",
-      "duration_hours": 0.42
+      "duration_hours": 0.42,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-IAM-02",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2025-06-05T23:49:48Z",
       "failed_commit": "b23b62e26d5bf04642fcf9a315790fa340e27e7f",
       "reason": "No users found \u2014 identity model appears empty",
@@ -2496,10 +2688,11 @@
       "requirement": "A secure cloud service offering will protect user data, control access, and apply zero trust principles.",
       "remediated_at": "2025-06-06T11:23:25.401040Z",
       "remediation_commit": "a5986b7643f641840e17cf702564e36030e2bd07",
-      "duration_hours": 11.56
+      "duration_hours": 11.56,
+      "legacy_ksi_id": "KSI-IAM-02"
     },
     {
-      "ksi_id": "KSI-SVC-06",
+      "ksi_id": "KSI-SVC-ASM",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "No KMS keys found \u2014 cannot confirm key lifecycle management",
@@ -2508,7 +2701,8 @@
       "requirement": "A secure cloud service offering will follow FedRAMP encryption policies, continuously verify information resource integrity, and restrict access to third-party information resources.",
       "remediated_at": "2025-06-06T11:23:25.401040Z",
       "remediation_commit": "a5986b7643f641840e17cf702564e36030e2bd07",
-      "duration_hours": 7.59
+      "duration_hours": 7.59,
+      "legacy_ksi_id": "KSI-SVC-06"
     },
     {
       "ksi_id": "KSI-CMT-05",
@@ -2520,10 +2714,12 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-07T01:31:35.104663Z",
       "remediation_commit": "4318fe1ea056d06b8070ea10c88141668dfbe859",
-      "duration_hours": 21.17
+      "duration_hours": 21.17,
+      "legacy_ksi_id": "KSI-CMT-05",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2025-06-06T03:48:06.017208Z",
       "failed_commit": "000b624321cb120799f6dcd4cff08894a6468c50",
       "reason": "No Security Hub findings related to past incidents found (empty Findings list)",
@@ -2532,10 +2728,11 @@
       "requirement": "A secure cloud service offering will document, report, and analyze security incidents to ensure regulatory compliance and continuous security improvement.",
       "remediated_at": "2025-06-07T05:56:56.375386Z",
       "remediation_commit": "51728cb2bba9f9a82c7eed10d1ab914803896658",
-      "duration_hours": 26.15
+      "duration_hours": 26.15,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
-      "ksi_id": "KSI-INR-03",
+      "ksi_id": "KSI-INR-AAR",
       "failed_at": "2025-06-06T04:21:09.354677Z",
       "failed_commit": "400485341a877700e30c29f7d2815620d323dc01",
       "reason": "No comprehensive after action reporting and lessons learned integration found in evidence_v2/KSI-INR-03/",
@@ -2544,7 +2741,8 @@
       "requirement": "A secure cloud service offering will document, report, and analyze security incidents to ensure regulatory compliance and continuous security improvement.",
       "remediated_at": "2025-06-07T06:41:55.489158Z",
       "remediation_commit": "c2394bcd19ba6af645d6dd28fd885bc344621e32",
-      "duration_hours": 26.35
+      "duration_hours": 26.35,
+      "legacy_ksi_id": "KSI-INR-03"
     },
     {
       "ksi_id": "KSI-PIY-07",
@@ -2556,7 +2754,9 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-07T07:21:33.553764Z",
       "remediation_commit": "4d96df5f4af673e9467e269505fdb48a5573e53e",
-      "duration_hours": 27.01
+      "duration_hours": 27.01,
+      "legacy_ksi_id": "KSI-PIY-07",
+      "retired_pre_cr26": true
     },
     {
       "ksi_id": "KSI-PIY-05",
@@ -2568,10 +2768,12 @@
       "requirement": "A secure cloud service offering will have intentional, organized, universal guidance for how every information resource, including personnel, is secured.",
       "remediated_at": "2025-06-07T07:36:14.226040Z",
       "remediation_commit": "9bd73b505135c25d5dbd62e46572cb6805ff1bd7",
-      "duration_hours": 136.77
+      "duration_hours": 136.77,
+      "legacy_ksi_id": "KSI-PIY-05",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-TPR-03",
+      "ksi_id": "KSI-SCR-MIT",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "SecurityHub hub not described",
@@ -2580,10 +2782,11 @@
       "requirement": "A secure cloud service offering will understand, monitor, and manage supply chain risks from third-party information resources.",
       "remediated_at": "2025-06-07T07:47:00.338439Z",
       "remediation_commit": "6d801db9adfd05d1ab3403265d8391406dd10771",
-      "duration_hours": 136.95
+      "duration_hours": 136.95,
+      "legacy_ksi_id": "KSI-TPR-03"
     },
     {
-      "ksi_id": "KSI-CNA-07",
+      "ksi_id": "KSI-CNA-IBP",
       "failed_at": "2025-06-06T04:21:09.354677Z",
       "failed_commit": "400485341a877700e30c29f7d2815620d323dc01",
       "reason": "No Config rules data found",
@@ -2592,10 +2795,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-07T20:23:23.920130Z",
       "remediation_commit": "6d3276ed0491f8f3b210580ab2ceff44b7ea3f1b",
-      "duration_hours": 40.04
+      "duration_hours": 40.04,
+      "legacy_ksi_id": "KSI-CNA-07"
     },
     {
-      "ksi_id": "KSI-CMT-03",
+      "ksi_id": "KSI-CMT-VTD",
       "failed_at": "2025-06-01T14:50:00Z",
       "failed_commit": "6eab0b0adbdbcf10a7477ab0439b3f28a9bdb166",
       "reason": "No rule defined for this KSI",
@@ -2604,10 +2808,11 @@
       "requirement": "A secure cloud service provider will ensure that all system changes are properly documented and configuration baselines are updated accordingly.",
       "remediated_at": "2025-06-09T08:02:50.289304Z",
       "remediation_commit": "c84fda15c5b769bed60d18ead5fd20de4492f6ed",
-      "duration_hours": 185.21
+      "duration_hours": 185.21,
+      "legacy_ksi_id": "KSI-CMT-03"
     },
     {
-      "ksi_id": "KSI-CNA-04",
+      "ksi_id": "KSI-CNA-DFP",
       "failed_at": "2025-06-09T21:56:37.398319Z",
       "failed_commit": "620aba66c27d6d0a208511807e675d4120f6c92b",
       "reason": "No Infrastructure as Code patterns found",
@@ -2616,10 +2821,11 @@
       "requirement": "Use immutable infrastructure patterns",
       "remediated_at": "2025-06-09T22:20:52.630197Z",
       "remediation_commit": "88eaad74e17e4ae897604307f861a76d3413c879",
-      "duration_hours": 0.4
+      "duration_hours": 0.4,
+      "legacy_ksi_id": "KSI-CNA-04"
     },
     {
-      "ksi_id": "KSI-CNA-05",
+      "ksi_id": "KSI-CNA-RVP",
       "failed_at": "2025-06-03T01:06:31Z",
       "failed_commit": "046413fbfc5b70b6ff327167ee064e8c0ccb7e2e",
       "reason": "No VPCs found",
@@ -2628,10 +2834,11 @@
       "requirement": "A secure cloud service offering will use cloud native architecture and design principles to enforce and enhance the Confidentiality, Integrity and Availability of the system.",
       "remediated_at": "2025-06-09T22:20:52.630197Z",
       "remediation_commit": "88eaad74e17e4ae897604307f861a76d3413c879",
-      "duration_hours": 165.24
+      "duration_hours": 165.24,
+      "legacy_ksi_id": "KSI-CNA-05"
     },
     {
-      "ksi_id": "KSI-CNA-01",
+      "ksi_id": "KSI-CNA-RNT",
       "failed_at": "2025-06-09T21:56:37.398319Z",
       "failed_commit": "620aba66c27d6d0a208511807e675d4120f6c92b",
       "reason": "No VPCs found",
@@ -2640,10 +2847,11 @@
       "requirement": "Configure ALL information resources to limit inbound and outbound traffic",
       "remediated_at": "2025-06-09T22:46:08.261822Z",
       "remediation_commit": "57825425d4fe020a2cb0ff3c7e762e3bb2292ebc",
-      "duration_hours": 0.83
+      "duration_hours": 0.83,
+      "legacy_ksi_id": "KSI-CNA-01"
     },
     {
-      "ksi_id": "KSI-CNA-02",
+      "ksi_id": "KSI-CNA-MAT",
       "failed_at": "2025-06-09T22:20:52.630197Z",
       "failed_commit": "88eaad74e17e4ae897604307f861a76d3413c879",
       "reason": "Insufficient attack surface controls (0%) - critical security gaps:  CRITICAL: All 6 subnets are public (maximum attack surface);  Excellent AZ segmentation: 6 subnets across 6 availability zones;  No micro-segmentation: Using default security groups only;  Lateral movement barriers: 1/1 security groups with specific rules; \u2139 No RDS instances found;  Lambda exposure: 1 functions not in VPC (limited network isolation);  Using default Network ACLs only (no additional subnet isolation)",
@@ -2652,10 +2860,11 @@
       "requirement": "Design systems to minimize the attack surface and minimize lateral movement if compromised",
       "remediated_at": "2025-06-09T22:46:08.261822Z",
       "remediation_commit": "57825425d4fe020a2cb0ff3c7e762e3bb2292ebc",
-      "duration_hours": 0.42
+      "duration_hours": 0.42,
+      "legacy_ksi_id": "KSI-CNA-02"
     },
     {
-      "ksi_id": "KSI-CNA-03",
+      "ksi_id": "KSI-CNA-ULN",
       "failed_at": "2025-06-09T22:20:52.630197Z",
       "failed_commit": "88eaad74e17e4ae897604307f861a76d3413c879",
       "reason": "Insufficient logical networking (3%) - no meaningful traffic flow controls:  No logical routing: Using default route tables only (1 total);  No custom traffic filtering: Using default NACLs only (1 total);  No VPC endpoints - missing private service routing; \u2139 No Transit Gateways found (acceptable for simple architectures); \u2139 No VPC peering found (acceptable for single-VPC architectures);  No load balancers found - missing application traffic control;  No NAT Gateways found - potential uncontrol",
@@ -2664,7 +2873,8 @@
       "requirement": "Use logical networking for traffic flow controls",
       "remediated_at": "2025-06-09T23:35:36.466976Z",
       "remediation_commit": "e6daa31a67e2641c7ed0075abe8bdf38a5ec4146",
-      "duration_hours": 1.25
+      "duration_hours": 1.25,
+      "legacy_ksi_id": "KSI-CNA-03"
     },
     {
       "ksi_id": "KSI-TPR-02",
@@ -2676,10 +2886,12 @@
       "requirement": "Regularly confirm that services handling federal information or are likely to impact the confidentiality, integrity, or availability of federal information are FedRAMP authorized and securely configured",
       "remediated_at": "2025-06-10T22:18:00.904838Z",
       "remediation_commit": "f25c56bbe8e35a0e454dc37d5a36c1472bb2ec32",
-      "duration_hours": 3.45
+      "duration_hours": 3.45,
+      "legacy_ksi_id": "KSI-TPR-02",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-06-24T02:05:21.906659Z",
       "failed_commit": "00af11c171741ad916e9d48b81df0e20c6dba606",
       "reason": "Exception during evaluation: 'list' object has no attribute 'get'",
@@ -2688,10 +2900,11 @@
       "requirement": "Define Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO)",
       "remediated_at": "2025-06-24T02:28:31.780838Z",
       "remediation_commit": "7981b2ba0963421a8041b4e4a4209e707570848a",
-      "duration_hours": 0.39
+      "duration_hours": 0.39,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-RPL-02",
+      "ksi_id": "KSI-RPL-ARP",
       "failed_at": "2025-06-24T02:05:21.906659Z",
       "failed_commit": "00af11c171741ad916e9d48b81df0e20c6dba606",
       "reason": "Exception during evaluation: 'list' object has no attribute 'get'",
@@ -2700,10 +2913,11 @@
       "requirement": "Develop and maintain a recovery plan that aligns with defined recovery objectives",
       "remediated_at": "2025-06-24T02:28:31.780838Z",
       "remediation_commit": "7981b2ba0963421a8041b4e4a4209e707570848a",
-      "duration_hours": 0.39
+      "duration_hours": 0.39,
+      "legacy_ksi_id": "KSI-RPL-02"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-06-24T02:05:21.906659Z",
       "failed_commit": "00af11c171741ad916e9d48b81df0e20c6dba606",
       "reason": "Exception during evaluation: 'list' object has no attribute 'get'",
@@ -2712,10 +2926,11 @@
       "requirement": "Perform system backups aligned with recovery objectives",
       "remediated_at": "2025-06-24T02:28:31.780838Z",
       "remediation_commit": "7981b2ba0963421a8041b4e4a4209e707570848a",
-      "duration_hours": 0.39
+      "duration_hours": 0.39,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2025-06-24T02:05:21.906659Z",
       "failed_commit": "00af11c171741ad916e9d48b81df0e20c6dba606",
       "reason": "Exception during evaluation: 'list' object has no attribute 'get'",
@@ -2724,10 +2939,11 @@
       "requirement": "A secure cloud service offering will define, maintain, and test incident response plan(s) and recovery capabilities to ensure minimal service disruption and data loss during incidents and contingencies.",
       "remediated_at": "2025-06-24T02:28:31.780838Z",
       "remediation_commit": "7981b2ba0963421a8041b4e4a4209e707570848a",
-      "duration_hours": 0.39
+      "duration_hours": 0.39,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
-      "ksi_id": "KSI-CNA-04",
+      "ksi_id": "KSI-CNA-DFP",
       "failed_at": "2025-06-24T18:59:07.085987Z",
       "failed_commit": "d11743435004b3292f588bab4105cc74ec487bc6",
       "reason": "Exception during evaluation: No module named 'dateutil'",
@@ -2736,10 +2952,11 @@
       "requirement": "Use immutable infrastructure patterns",
       "remediated_at": "2025-06-25T00:49:17.089767Z",
       "remediation_commit": "83083ca8fa81ee57bffb604a0aa677dfcce6a88b",
-      "duration_hours": 5.84
+      "duration_hours": 5.84,
+      "legacy_ksi_id": "KSI-CNA-04"
     },
     {
-      "ksi_id": "KSI-CMT-02",
+      "ksi_id": "KSI-CMT-RMV",
       "failed_at": "2025-06-26T02:53:32.056322Z",
       "failed_commit": "253daa2b427d03570bf5c89f7a4f84bb643f0a89",
       "reason": "Exception during evaluation: No module named 'dateutil'",
@@ -2748,10 +2965,11 @@
       "requirement": "Track and control changes to information resources",
       "remediated_at": "2025-06-26T03:03:33.112004Z",
       "remediation_commit": "0e9c2ca042aff8c15838c35b21f8e56e5f8b5829",
-      "duration_hours": 0.17
+      "duration_hours": 0.17,
+      "legacy_ksi_id": "KSI-CMT-02"
     },
     {
-      "ksi_id": "KSI-MLA-05",
+      "ksi_id": "KSI-MLA-EVC",
       "failed_at": "2025-08-30T00:42:19.697165Z",
       "failed_commit": "f6f17b33e022b0de61ac71c069b4a063b1ae7dc3",
       "reason": "Exception during evaluation: name 'scanning_score' is not defined",
@@ -2760,10 +2978,11 @@
       "requirement": "Perform Infrastructure as Code and configuration evaluation and testing",
       "remediated_at": "2025-08-30T02:34:50.922010Z",
       "remediation_commit": "b4aaacb273002640de33aebc3fed7af9af3fbe3f",
-      "duration_hours": 1.88
+      "duration_hours": 1.88,
+      "legacy_ksi_id": "KSI-MLA-05"
     },
     {
-      "ksi_id": "KSI-PIY-01",
+      "ksi_id": "KSI-PIY-GIV",
       "failed_at": "2025-09-09T22:13:15.378798Z",
       "failed_commit": "d6bef97a2160c48d067b6e1c0f4d6bbb1305ce37",
       "reason": "Inadequate information resource inventory:  No AWS resource inventory data;  Basic inventory documentation: complete_asset_inventory.xlsx",
@@ -2772,10 +2991,11 @@
       "requirement": "Establish and maintain complete inventories of all information resources",
       "remediated_at": "2025-09-09T22:43:59.530590Z",
       "remediation_commit": "a6255d3b834314e5b3271fee59b1305a2516b06a",
-      "duration_hours": 0.51
+      "duration_hours": 0.51,
+      "legacy_ksi_id": "KSI-PIY-01"
     },
     {
-      "ksi_id": "KSI-IAM-07",
+      "ksi_id": "KSI-IAM-AAM",
       "failed_at": "2025-09-15T00:44:55.341082Z",
       "failed_commit": "df5ec9001fa9e5de5b9e6791d955486206a2f881",
       "reason": "Exception during evaluation: name 'timezone' is not defined",
@@ -2784,10 +3004,11 @@
       "requirement": "Securely manage the lifecycle and privileges of all accounts, roles, and groups",
       "remediated_at": "2025-09-15T01:58:48.737493Z",
       "remediation_commit": "20e0131cb6839def89d778e6a0c0f11454fa0436",
-      "duration_hours": 1.23
+      "duration_hours": 1.23,
+      "legacy_ksi_id": "KSI-IAM-07"
     },
     {
-      "ksi_id": "KSI-SVC-09",
+      "ksi_id": "KSI-SVC-VCM",
       "failed_at": "2025-09-15T00:44:55.341082Z",
       "failed_commit": "df5ec9001fa9e5de5b9e6791d955486206a2f881",
       "reason": "Exception during evaluation: 'list' object has no attribute 'get'",
@@ -2796,10 +3017,11 @@
       "requirement": "Use mechanisms that continuously validate the authenticity and integrity of communications between information resources",
       "remediated_at": "2025-09-15T01:58:48.737493Z",
       "remediation_commit": "20e0131cb6839def89d778e6a0c0f11454fa0436",
-      "duration_hours": 1.23
+      "duration_hours": 1.23,
+      "legacy_ksi_id": "KSI-SVC-09"
     },
     {
-      "ksi_id": "KSI-PIY-01",
+      "ksi_id": "KSI-PIY-GIV",
       "failed_at": "2025-09-15T01:58:48.737493Z",
       "failed_commit": "20e0131cb6839def89d778e6a0c0f11454fa0436",
       "reason": "Inadequate information resource inventory:  No AWS resource inventory data;  Basic inventory documentation: complete_asset_inventory.xlsx",
@@ -2808,10 +3030,11 @@
       "requirement": "Establish and maintain complete inventories of all information resources",
       "remediated_at": "2025-09-15T03:11:49.638922Z",
       "remediation_commit": "70bbb2b6bfff76fae41421fbc45fb2629035dd39",
-      "duration_hours": 1.22
+      "duration_hours": 1.22,
+      "legacy_ksi_id": "KSI-PIY-01"
     },
     {
-      "ksi_id": "KSI-CED-03",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-09-15T00:44:55.341082Z",
       "failed_commit": "df5ec9001fa9e5de5b9e6791d955486206a2f881",
       "reason": "No developer security training program found: No evidence found",
@@ -2820,10 +3043,11 @@
       "requirement": "Require role-specific training for development and engineering staff covering best practices for delivering secure software",
       "remediated_at": "2025-09-15T21:53:18.762856Z",
       "remediation_commit": "f0c1e74dab0ea6280a9282dfe550312d75e6493c",
-      "duration_hours": 21.14
+      "duration_hours": 21.14,
+      "legacy_ksi_id": "KSI-CED-03"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-09-15T21:53:18.762856Z",
       "failed_commit": "f0c1e74dab0ea6280a9282dfe550312d75e6493c",
       "reason": "Exception during evaluation: 'list' object has no attribute 'get'",
@@ -2832,10 +3056,11 @@
       "requirement": "Define Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO)",
       "remediated_at": "2025-09-15T22:44:10.361572Z",
       "remediation_commit": "f7466a92807b53b7f6c72a08a8d10c7e9d31e8c2",
-      "duration_hours": 0.85
+      "duration_hours": 0.85,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-PIY-01",
+      "ksi_id": "KSI-PIY-GIV",
       "failed_at": "2025-09-15T23:47:46.093438Z",
       "failed_commit": "23d95fd24685daadc0d703e72d1afbdbf83d4636",
       "reason": "Exception during evaluation: 'list' object has no attribute 'get'",
@@ -2844,10 +3069,11 @@
       "requirement": "Establish and maintain complete inventories of all information resources",
       "remediated_at": "2025-09-16T00:12:53.493097Z",
       "remediation_commit": "1ddf9779e9eb2279572b6a47a1f4ef28e1ee74cd",
-      "duration_hours": 0.42
+      "duration_hours": 0.42,
+      "legacy_ksi_id": "KSI-PIY-01"
     },
     {
-      "ksi_id": "KSI-TPR-04",
+      "ksi_id": "KSI-SCR-MON",
       "failed_at": "2025-09-15T21:53:18.762856Z",
       "failed_commit": "f0c1e74dab0ea6280a9282dfe550312d75e6493c",
       "reason": "No automated third-party vulnerability monitoring infrastructure: No monitoring capabilities detected",
@@ -2856,10 +3082,11 @@
       "requirement": "Monitor third party software information resources for upstream vulnerabilities, with contractual notification requirements or active monitoring services",
       "remediated_at": "2025-09-17T07:11:02.477185Z",
       "remediation_commit": "3801f9657ec3bac25522e7d499328ed6263a666b",
-      "duration_hours": 33.3
+      "duration_hours": 33.3,
+      "legacy_ksi_id": "KSI-TPR-04"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2025-09-15T21:53:18.762856Z",
       "failed_commit": "f0c1e74dab0ea6280a9282dfe550312d75e6493c",
       "reason": "No automated incident tracking infrastructure: No incident tracking capabilities detected",
@@ -2868,10 +3095,11 @@
       "requirement": "Maintain a log of incidents and periodically review past incidents for patterns or vulnerabilities",
       "remediated_at": "2025-09-17T22:49:20.292962Z",
       "remediation_commit": "fe5af50136f2ae25e47d80cdbe4f97db9fc9a026",
-      "duration_hours": 48.93
+      "duration_hours": 48.93,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
-      "ksi_id": "KSI-CED-03",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-09-19T02:16:00.248240Z",
       "failed_commit": "14dc7cad24ded11f37c36dd4867f44dad1dc0947",
       "reason": "No automated developer training infrastructure found: No training automation detected",
@@ -2880,10 +3108,11 @@
       "requirement": "Require role-specific training for development and engineering staff covering best practices for delivering secure software",
       "remediated_at": "2025-09-19T02:41:18.813195Z",
       "remediation_commit": "373e87e5d969fdc601eafc97235f6cdd43c23844",
-      "duration_hours": 0.42
+      "duration_hours": 0.42,
+      "legacy_ksi_id": "KSI-CED-03"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2025-09-19T02:16:00.248240Z",
       "failed_commit": "14dc7cad24ded11f37c36dd4867f44dad1dc0947",
       "reason": "Insufficient evidence of an operational incident script (0%): No components of an automated incident script workflow were detected.",
@@ -2892,10 +3121,11 @@
       "requirement": "Maintain a log of incidents and periodically review past incidents for patterns or vulnerabilities",
       "remediated_at": "2025-09-19T02:41:18.813195Z",
       "remediation_commit": "373e87e5d969fdc601eafc97235f6cdd43c23844",
-      "duration_hours": 0.42
+      "duration_hours": 0.42,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-09-19T02:16:00.248240Z",
       "failed_commit": "14dc7cad24ded11f37c36dd4867f44dad1dc0947",
       "reason": "Insufficient technical recovery capability for defined RTO/RPO objectives (0%): No recovery infrastructure or objectives detected",
@@ -2904,10 +3134,11 @@
       "requirement": "Define Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO)",
       "remediated_at": "2025-09-19T02:41:18.813195Z",
       "remediation_commit": "373e87e5d969fdc601eafc97235f6cdd43c23844",
-      "duration_hours": 0.42
+      "duration_hours": 0.42,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-09-19T02:16:00.248240Z",
       "failed_commit": "14dc7cad24ded11f37c36dd4867f44dad1dc0947",
       "reason": "Insufficient backup implementation:  No AWS Backup plans found;  No backup execution data available for validation; \u2139 No EBS snapshots (acceptable if using AWS Backup exclusively)",
@@ -2916,10 +3147,11 @@
       "requirement": "Perform system backups aligned with recovery objectives",
       "remediated_at": "2025-09-19T02:41:18.813195Z",
       "remediation_commit": "373e87e5d969fdc601eafc97235f6cdd43c23844",
-      "duration_hours": 0.42
+      "duration_hours": 0.42,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2025-09-19T02:16:00.248240Z",
       "failed_commit": "14dc7cad24ded11f37c36dd4867f44dad1dc0947",
       "reason": "Insufficient recovery testing capability detected (0%): No recovery testing infrastructure found",
@@ -2928,10 +3160,11 @@
       "requirement": "Regularly test the capability to recover from incidents and contingencies",
       "remediated_at": "2025-09-19T02:41:18.813195Z",
       "remediation_commit": "373e87e5d969fdc601eafc97235f6cdd43c23844",
-      "duration_hours": 0.42
+      "duration_hours": 0.42,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
-      "ksi_id": "KSI-CED-03",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-09-19T05:45:02.921949Z",
       "failed_commit": "bde9b5494b1849534135500d56a71f47c3be3ba4",
       "reason": "No automated developer training infrastructure found: No training automation detected",
@@ -2940,10 +3173,11 @@
       "requirement": "Require role-specific training for development and engineering staff covering best practices for delivering secure software",
       "remediated_at": "2025-09-19T18:41:10.225125Z",
       "remediation_commit": "eff078ae23291cc8506855432234eccd7bbecb79",
-      "duration_hours": 12.94
+      "duration_hours": 12.94,
+      "legacy_ksi_id": "KSI-CED-03"
     },
     {
-      "ksi_id": "KSI-CMT-03",
+      "ksi_id": "KSI-CMT-VTD",
       "failed_at": "2025-09-19T16:25:45.112793Z",
       "failed_commit": "1c75a0893ad66ff051af6f0c6787efef4209950b",
       "reason": "No automated testing and validation infrastructure detected (8%):  Infrastructure validation: CloudFormation template testing capability",
@@ -2952,10 +3186,11 @@
       "requirement": "Implement persistent automated testing and validation of changes",
       "remediated_at": "2025-09-19T18:41:10.225125Z",
       "remediation_commit": "eff078ae23291cc8506855432234eccd7bbecb79",
-      "duration_hours": 2.26
+      "duration_hours": 2.26,
+      "legacy_ksi_id": "KSI-CMT-03"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2025-09-19T05:45:02.921949Z",
       "failed_commit": "bde9b5494b1849534135500d56a71f47c3be3ba4",
       "reason": "Insufficient evidence of an operational incident script (0%): No components of an automated incident script workflow were detected.",
@@ -2964,10 +3199,11 @@
       "requirement": "Maintain a log of incidents and periodically review past incidents for patterns or vulnerabilities",
       "remediated_at": "2025-09-19T18:41:10.225125Z",
       "remediation_commit": "eff078ae23291cc8506855432234eccd7bbecb79",
-      "duration_hours": 12.94
+      "duration_hours": 12.94,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
-      "ksi_id": "KSI-PIY-01",
+      "ksi_id": "KSI-PIY-GIV",
       "failed_at": "2025-09-19T05:45:02.921949Z",
       "failed_commit": "bde9b5494b1849534135500d56a71f47c3be3ba4",
       "reason": "Insufficient comprehensive inventory of information resources (0%): No comprehensive resource discovery detected",
@@ -2976,10 +3212,11 @@
       "requirement": "Generate inventories of information resources from authoritative sources",
       "remediated_at": "2025-09-19T18:41:10.225125Z",
       "remediation_commit": "eff078ae23291cc8506855432234eccd7bbecb79",
-      "duration_hours": 12.94
+      "duration_hours": 12.94,
+      "legacy_ksi_id": "KSI-PIY-01"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-09-19T05:45:02.921949Z",
       "failed_commit": "bde9b5494b1849534135500d56a71f47c3be3ba4",
       "reason": "Insufficient technical recovery capability for defined RTO/RPO objectives (0%): No recovery infrastructure or objectives detected",
@@ -2988,10 +3225,11 @@
       "requirement": "Define Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO)",
       "remediated_at": "2025-09-19T18:41:10.225125Z",
       "remediation_commit": "eff078ae23291cc8506855432234eccd7bbecb79",
-      "duration_hours": 12.94
+      "duration_hours": 12.94,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-09-19T05:45:02.921949Z",
       "failed_commit": "bde9b5494b1849534135500d56a71f47c3be3ba4",
       "reason": "Insufficient backup implementation:  No AWS Backup plans found;  No backup execution data available for validation; \u2139 No EBS snapshots (acceptable if using AWS Backup exclusively)",
@@ -3000,10 +3238,11 @@
       "requirement": "Perform system backups aligned with recovery objectives",
       "remediated_at": "2025-09-19T18:41:10.225125Z",
       "remediation_commit": "eff078ae23291cc8506855432234eccd7bbecb79",
-      "duration_hours": 12.94
+      "duration_hours": 12.94,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2025-09-19T05:45:02.921949Z",
       "failed_commit": "bde9b5494b1849534135500d56a71f47c3be3ba4",
       "reason": "Insufficient recovery testing capability detected (0%): No recovery testing infrastructure found",
@@ -3012,10 +3251,11 @@
       "requirement": "Regularly test the capability to recover from incidents and contingencies",
       "remediated_at": "2025-09-19T18:41:10.225125Z",
       "remediation_commit": "eff078ae23291cc8506855432234eccd7bbecb79",
-      "duration_hours": 12.94
+      "duration_hours": 12.94,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
-      "ksi_id": "KSI-TPR-04",
+      "ksi_id": "KSI-SCR-MON",
       "failed_at": "2025-09-19T05:45:02.921949Z",
       "failed_commit": "bde9b5494b1849534135500d56a71f47c3be3ba4",
       "reason": "No third-party package vulnerability monitoring capability dete",
@@ -3024,10 +3264,11 @@
       "requirement": "Monitor third party software information resources for upstream vulnerabilities, with contractual notification requirements or active monitoring services",
       "remediated_at": "2025-09-19T18:41:10.225125Z",
       "remediation_commit": "eff078ae23291cc8506855432234eccd7bbecb79",
-      "duration_hours": 12.94
+      "duration_hours": 12.94,
+      "legacy_ksi_id": "KSI-TPR-04"
     },
     {
-      "ksi_id": "KSI-CMT-01",
+      "ksi_id": "KSI-CMT-LMC",
       "failed_at": "2025-09-19T23:58:08.205168Z",
       "failed_commit": "95d53183457e4f8a7f60dd52c1d2eb6d9c16c169",
       "reason": "No system modification logging capability found (0%):  No CloudTrail trails found for system modification tracking; \u2139 AWS Config not configured (acceptable for low-impact pilot environments); \u2139 No CloudWatch log groups for application/system event logging; \u2139 No EventBridge rules for real-time change detection; \u2139 No CloudWatch alarms for modification monitoring; \u2139 No SNS topics for modification notifications; \u2139 No Lambda functions for automated modification response; \u2139 No SSM instances for instan",
@@ -3036,10 +3277,11 @@
       "requirement": "Log and monitor service modifications",
       "remediated_at": "2025-09-20T00:52:04.118965Z",
       "remediation_commit": "88df44a4d16bd75971cd2d095a7628149a53afb6",
-      "duration_hours": 0.9
+      "duration_hours": 0.9,
+      "legacy_ksi_id": "KSI-CMT-01"
     },
     {
-      "ksi_id": "KSI-CMT-03",
+      "ksi_id": "KSI-CMT-VTD",
       "failed_at": "2025-09-19T23:58:08.205168Z",
       "failed_commit": "95d53183457e4f8a7f60dd52c1d2eb6d9c16c169",
       "reason": "No automated testing and validation infrastructure detected (8%):  Infrastructure validation: CloudFormation template testing capability",
@@ -3048,10 +3290,11 @@
       "requirement": "Implement persistent automated testing and validation of changes",
       "remediated_at": "2025-09-20T00:52:04.118965Z",
       "remediation_commit": "88df44a4d16bd75971cd2d095a7628149a53afb6",
-      "duration_hours": 0.9
+      "duration_hours": 0.9,
+      "legacy_ksi_id": "KSI-CMT-03"
     },
     {
-      "ksi_id": "KSI-IAM-07",
+      "ksi_id": "KSI-IAM-AAM",
       "failed_at": "2025-09-19T23:58:08.205168Z",
       "failed_commit": "95d53183457e4f8a7f60dd52c1d2eb6d9c16c169",
       "reason": "Insufficient account lifecycle management (0%):  User-heavy architecture: 0 roles vs 0 users; \u2139 No recent role modifications detected",
@@ -3060,10 +3303,11 @@
       "requirement": "Securely manage the lifecycle and privileges of all accounts, roles, and groups",
       "remediated_at": "2025-09-20T00:52:04.118965Z",
       "remediation_commit": "88df44a4d16bd75971cd2d095a7628149a53afb6",
-      "duration_hours": 0.9
+      "duration_hours": 0.9,
+      "legacy_ksi_id": "KSI-IAM-07"
     },
     {
-      "ksi_id": "KSI-MLA-01",
+      "ksi_id": "KSI-MLA-OSM",
       "failed_at": "2025-09-19T23:58:08.205168Z",
       "failed_commit": "95d53183457e4f8a7f60dd52c1d2eb6d9c16c169",
       "reason": "Insufficient SIEM/centralized logging capabilities (6%):  No CloudTrail found - required for centralized logging;  No CloudWatch log groups found; \u2139 No CloudWatch alarms found for automated log analysis;  Security Hub available: Ready for advanced SIEM capabilities; \u2139 No Config delivery channels found for compliance log delivery",
@@ -3072,10 +3316,11 @@
       "requirement": "Operate a Security Information and Event Management (SIEM) or similar system(s) for centralized, tamper-resistant logging of events, activities, and changes",
       "remediated_at": "2025-09-20T00:52:04.118965Z",
       "remediation_commit": "88df44a4d16bd75971cd2d095a7628149a53afb6",
-      "duration_hours": 0.9
+      "duration_hours": 0.9,
+      "legacy_ksi_id": "KSI-MLA-01"
     },
     {
-      "ksi_id": "KSI-MLA-05",
+      "ksi_id": "KSI-MLA-EVC",
       "failed_at": "2025-09-19T23:58:08.205168Z",
       "failed_commit": "95d53183457e4f8a7f60dd52c1d2eb6d9c16c169",
       "reason": "No Infrastructure as Code evaluation capability:  No CloudFormation stacks found for IaC evaluation;  No SSM parameters for centralized configuration management;  No Config rules for infrastructure evaluation; \u2139 No CI/CD automation (acceptable for Control Tower managed infrastructure)",
@@ -3084,10 +3329,11 @@
       "requirement": "Perform Infrastructure as Code and configuration evaluation and testing",
       "remediated_at": "2025-09-20T00:52:04.118965Z",
       "remediation_commit": "88df44a4d16bd75971cd2d095a7628149a53afb6",
-      "duration_hours": 0.9
+      "duration_hours": 0.9,
+      "legacy_ksi_id": "KSI-MLA-05"
     },
     {
-      "ksi_id": "KSI-MLA-07",
+      "ksi_id": "KSI-MLA-LET",
       "failed_at": "2025-09-19T23:58:08.205168Z",
       "failed_commit": "95d53183457e4f8a7f60dd52c1d2eb6d9c16c169",
       "reason": "Insufficient automated monitoring inventory (0%):",
@@ -3096,10 +3342,11 @@
       "requirement": "Maintain a list of information resources and event types that will be monitored, logged, and audited",
       "remediated_at": "2025-09-20T00:52:04.118965Z",
       "remediation_commit": "88df44a4d16bd75971cd2d095a7628149a53afb6",
-      "duration_hours": 0.9
+      "duration_hours": 0.9,
+      "legacy_ksi_id": "KSI-MLA-07"
     },
     {
-      "ksi_id": "KSI-MLA-08",
+      "ksi_id": "KSI-MLA-ALA",
       "failed_at": "2025-09-19T23:58:08.205168Z",
       "failed_commit": "95d53183457e4f8a7f60dd52c1d2eb6d9c16c169",
       "reason": "Insufficient RBAC log access control for Moderate baseline (0%):  No specialized log access roles identified",
@@ -3108,10 +3355,11 @@
       "requirement": "Use a least-privileged, role and attribute-based, and just-in-time access authorization model for access to log data",
       "remediated_at": "2025-09-20T00:52:04.118965Z",
       "remediation_commit": "88df44a4d16bd75971cd2d095a7628149a53afb6",
-      "duration_hours": 0.9
+      "duration_hours": 0.9,
+      "legacy_ksi_id": "KSI-MLA-08"
     },
     {
-      "ksi_id": "KSI-PIY-01",
+      "ksi_id": "KSI-PIY-GIV",
       "failed_at": "2025-09-19T23:58:08.205168Z",
       "failed_commit": "95d53183457e4f8a7f60dd52c1d2eb6d9c16c169",
       "reason": "Insufficient comprehensive inventory of information resources (0%): No comprehensive resource discovery detected",
@@ -3120,10 +3368,11 @@
       "requirement": "Generate inventories of information resources from authoritative sources",
       "remediated_at": "2025-09-20T00:52:04.118965Z",
       "remediation_commit": "88df44a4d16bd75971cd2d095a7628149a53afb6",
-      "duration_hours": 0.9
+      "duration_hours": 0.9,
+      "legacy_ksi_id": "KSI-PIY-01"
     },
     {
-      "ksi_id": "KSI-CED-03",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-09-19T23:58:08.205168Z",
       "failed_commit": "95d53183457e4f8a7f60dd52c1d2eb6d9c16c169",
       "reason": "No automated developer training infrastructure found: No training automation detected",
@@ -3132,10 +3381,11 @@
       "requirement": "Require role-specific training for development and engineering staff covering best practices for delivering secure software",
       "remediated_at": "2025-09-20T01:37:25.572822Z",
       "remediation_commit": "35615f45139a7268202a8947d7639e278a0cc581",
-      "duration_hours": 1.65
+      "duration_hours": 1.65,
+      "legacy_ksi_id": "KSI-CED-03"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-09-19T23:58:08.205168Z",
       "failed_commit": "95d53183457e4f8a7f60dd52c1d2eb6d9c16c169",
       "reason": "Insufficient technical recovery capability for defined RTO/RPO objectives (0%): No recovery infrastructure or objectives detected",
@@ -3144,10 +3394,11 @@
       "requirement": "Define Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO)",
       "remediated_at": "2025-09-20T01:37:25.572822Z",
       "remediation_commit": "35615f45139a7268202a8947d7639e278a0cc581",
-      "duration_hours": 1.65
+      "duration_hours": 1.65,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-09-19T23:58:08.205168Z",
       "failed_commit": "95d53183457e4f8a7f60dd52c1d2eb6d9c16c169",
       "reason": "Insufficient backup implementation:  No AWS Backup plans found;  No backup execution data available for validation; \u2139 No EBS snapshots (acceptable if using AWS Backup exclusively)",
@@ -3156,10 +3407,11 @@
       "requirement": "Perform system backups aligned with recovery objectives",
       "remediated_at": "2025-09-20T01:37:25.572822Z",
       "remediation_commit": "35615f45139a7268202a8947d7639e278a0cc581",
-      "duration_hours": 1.65
+      "duration_hours": 1.65,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2025-09-19T23:58:08.205168Z",
       "failed_commit": "95d53183457e4f8a7f60dd52c1d2eb6d9c16c169",
       "reason": "Insufficient recovery testing capability detected (0%): No recovery testing infrastructure found",
@@ -3168,10 +3420,11 @@
       "requirement": "Regularly test the capability to recover from incidents and contingencies",
       "remediated_at": "2025-09-20T01:37:25.572822Z",
       "remediation_commit": "35615f45139a7268202a8947d7639e278a0cc581",
-      "duration_hours": 1.65
+      "duration_hours": 1.65,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
-      "ksi_id": "KSI-TPR-04",
+      "ksi_id": "KSI-SCR-MON",
       "failed_at": "2025-09-19T23:58:08.205168Z",
       "failed_commit": "95d53183457e4f8a7f60dd52c1d2eb6d9c16c169",
       "reason": "No third-party package vulnerability monitoring capability dete",
@@ -3180,10 +3433,11 @@
       "requirement": "Monitor third party software information resources for upstream vulnerabilities, with contractual notification requirements or active monitoring services",
       "remediated_at": "2025-09-20T01:37:25.572822Z",
       "remediation_commit": "35615f45139a7268202a8947d7639e278a0cc581",
-      "duration_hours": 1.65
+      "duration_hours": 1.65,
+      "legacy_ksi_id": "KSI-TPR-04"
     },
     {
-      "ksi_id": "KSI-CED-03",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-09-20T02:58:27.605038Z",
       "failed_commit": "2dba9071c9014058d890b6f1b2546034b1081dd0",
       "reason": "No automated developer training infrastructure found: No training automation detected",
@@ -3192,10 +3446,11 @@
       "requirement": "Require role-specific training for development and engineering staff covering best practices for delivering secure software",
       "remediated_at": "2025-09-20T05:19:49.833405Z",
       "remediation_commit": "cdd85e969c2ecde318d9922d77a2ac40244c01c1",
-      "duration_hours": 2.36
+      "duration_hours": 2.36,
+      "legacy_ksi_id": "KSI-CED-03"
     },
     {
-      "ksi_id": "KSI-CMT-01",
+      "ksi_id": "KSI-CMT-LMC",
       "failed_at": "2025-09-20T02:58:27.605038Z",
       "failed_commit": "2dba9071c9014058d890b6f1b2546034b1081dd0",
       "reason": "No system modification logging capability found (0%):  No CloudTrail trails found for system modification tracking; \u2139 AWS Config not configured (acceptable for low-impact pilot environments); \u2139 No CloudWatch log groups for application/system event logging; \u2139 No EventBridge rules for real-time change detection; \u2139 No CloudWatch alarms for modification monitoring; \u2139 No SNS topics for modification notifications; \u2139 No Lambda functions for automated modification response; \u2139 No SSM instances for instan",
@@ -3204,10 +3459,11 @@
       "requirement": "Log and monitor service modifications",
       "remediated_at": "2025-09-20T05:19:49.833405Z",
       "remediation_commit": "cdd85e969c2ecde318d9922d77a2ac40244c01c1",
-      "duration_hours": 2.36
+      "duration_hours": 2.36,
+      "legacy_ksi_id": "KSI-CMT-01"
     },
     {
-      "ksi_id": "KSI-CMT-03",
+      "ksi_id": "KSI-CMT-VTD",
       "failed_at": "2025-09-20T02:58:27.605038Z",
       "failed_commit": "2dba9071c9014058d890b6f1b2546034b1081dd0",
       "reason": "No automated testing and validation infrastructure detected (8%):  Infrastructure validation: CloudFormation template testing capability",
@@ -3216,10 +3472,11 @@
       "requirement": "Implement persistent automated testing and validation of changes",
       "remediated_at": "2025-09-20T05:19:49.833405Z",
       "remediation_commit": "cdd85e969c2ecde318d9922d77a2ac40244c01c1",
-      "duration_hours": 2.36
+      "duration_hours": 2.36,
+      "legacy_ksi_id": "KSI-CMT-03"
     },
     {
-      "ksi_id": "KSI-IAM-07",
+      "ksi_id": "KSI-IAM-AAM",
       "failed_at": "2025-09-20T02:58:27.605038Z",
       "failed_commit": "2dba9071c9014058d890b6f1b2546034b1081dd0",
       "reason": "Insufficient account lifecycle management (0%):  User-heavy architecture: 0 roles vs 0 users; \u2139 No recent role modifications detected",
@@ -3228,10 +3485,11 @@
       "requirement": "Securely manage the lifecycle and privileges of all accounts, roles, and groups",
       "remediated_at": "2025-09-20T05:19:49.833405Z",
       "remediation_commit": "cdd85e969c2ecde318d9922d77a2ac40244c01c1",
-      "duration_hours": 2.36
+      "duration_hours": 2.36,
+      "legacy_ksi_id": "KSI-IAM-07"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2025-09-19T23:58:08.205168Z",
       "failed_commit": "95d53183457e4f8a7f60dd52c1d2eb6d9c16c169",
       "reason": "KSI-INR-02 NOT MET (score: 0): Missing - need 2 more EventBridge rules, need 4 more log groups, enable GuardDuty or Security Hub, no automation evidence. Found: No components detected",
@@ -3240,10 +3498,11 @@
       "requirement": "Maintain a log of incidents and periodically review past incidents for patterns or vulnerabilities",
       "remediated_at": "2025-09-20T05:19:49.833405Z",
       "remediation_commit": "cdd85e969c2ecde318d9922d77a2ac40244c01c1",
-      "duration_hours": 5.36
+      "duration_hours": 5.36,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
-      "ksi_id": "KSI-MLA-01",
+      "ksi_id": "KSI-MLA-OSM",
       "failed_at": "2025-09-20T02:58:27.605038Z",
       "failed_commit": "2dba9071c9014058d890b6f1b2546034b1081dd0",
       "reason": "Insufficient SIEM/centralized logging capabilities (6%):  No CloudTrail found - required for centralized logging;  No CloudWatch log groups found; \u2139 No CloudWatch alarms found for automated log analysis;  Security Hub available: Ready for advanced SIEM capabilities; \u2139 No Config delivery channels found for compliance log delivery",
@@ -3252,10 +3511,11 @@
       "requirement": "Operate a Security Information and Event Management (SIEM) or similar system(s) for centralized, tamper-resistant logging of events, activities, and changes",
       "remediated_at": "2025-09-20T05:19:49.833405Z",
       "remediation_commit": "cdd85e969c2ecde318d9922d77a2ac40244c01c1",
-      "duration_hours": 2.36
+      "duration_hours": 2.36,
+      "legacy_ksi_id": "KSI-MLA-01"
     },
     {
-      "ksi_id": "KSI-MLA-05",
+      "ksi_id": "KSI-MLA-EVC",
       "failed_at": "2025-09-20T02:58:27.605038Z",
       "failed_commit": "2dba9071c9014058d890b6f1b2546034b1081dd0",
       "reason": "No Infrastructure as Code evaluation capability:  No CloudFormation stacks found for IaC evaluation;  No SSM parameters for centralized configuration management;  No Config rules for infrastructure evaluation; \u2139 No CI/CD automation (acceptable for Control Tower managed infrastructure)",
@@ -3264,10 +3524,11 @@
       "requirement": "Perform Infrastructure as Code and configuration evaluation and testing",
       "remediated_at": "2025-09-20T05:19:49.833405Z",
       "remediation_commit": "cdd85e969c2ecde318d9922d77a2ac40244c01c1",
-      "duration_hours": 2.36
+      "duration_hours": 2.36,
+      "legacy_ksi_id": "KSI-MLA-05"
     },
     {
-      "ksi_id": "KSI-MLA-07",
+      "ksi_id": "KSI-MLA-LET",
       "failed_at": "2025-09-20T02:58:27.605038Z",
       "failed_commit": "2dba9071c9014058d890b6f1b2546034b1081dd0",
       "reason": "Insufficient automated monitoring inventory (0%):",
@@ -3276,10 +3537,11 @@
       "requirement": "Maintain a list of information resources and event types that will be monitored, logged, and audited",
       "remediated_at": "2025-09-20T05:19:49.833405Z",
       "remediation_commit": "cdd85e969c2ecde318d9922d77a2ac40244c01c1",
-      "duration_hours": 2.36
+      "duration_hours": 2.36,
+      "legacy_ksi_id": "KSI-MLA-07"
     },
     {
-      "ksi_id": "KSI-MLA-08",
+      "ksi_id": "KSI-MLA-ALA",
       "failed_at": "2025-09-20T02:58:27.605038Z",
       "failed_commit": "2dba9071c9014058d890b6f1b2546034b1081dd0",
       "reason": "Insufficient RBAC log access control for Moderate baseline (0%):  No specialized log access roles identified",
@@ -3288,10 +3550,11 @@
       "requirement": "Use a least-privileged, role and attribute-based, and just-in-time access authorization model for access to log data",
       "remediated_at": "2025-09-20T05:19:49.833405Z",
       "remediation_commit": "cdd85e969c2ecde318d9922d77a2ac40244c01c1",
-      "duration_hours": 2.36
+      "duration_hours": 2.36,
+      "legacy_ksi_id": "KSI-MLA-08"
     },
     {
-      "ksi_id": "KSI-PIY-01",
+      "ksi_id": "KSI-PIY-GIV",
       "failed_at": "2025-09-20T02:58:27.605038Z",
       "failed_commit": "2dba9071c9014058d890b6f1b2546034b1081dd0",
       "reason": "Insufficient comprehensive inventory of information resources (0%): No comprehensive resource discovery detected",
@@ -3300,10 +3563,11 @@
       "requirement": "Generate inventories of information resources from authoritative sources",
       "remediated_at": "2025-09-20T05:19:49.833405Z",
       "remediation_commit": "cdd85e969c2ecde318d9922d77a2ac40244c01c1",
-      "duration_hours": 2.36
+      "duration_hours": 2.36,
+      "legacy_ksi_id": "KSI-PIY-01"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-09-20T02:58:27.605038Z",
       "failed_commit": "2dba9071c9014058d890b6f1b2546034b1081dd0",
       "reason": "Insufficient technical recovery capability for defined RTO/RPO objectives (0%): No recovery infrastructure or objectives detected",
@@ -3312,10 +3576,11 @@
       "requirement": "Define Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO)",
       "remediated_at": "2025-09-20T05:19:49.833405Z",
       "remediation_commit": "cdd85e969c2ecde318d9922d77a2ac40244c01c1",
-      "duration_hours": 2.36
+      "duration_hours": 2.36,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-09-20T02:58:27.605038Z",
       "failed_commit": "2dba9071c9014058d890b6f1b2546034b1081dd0",
       "reason": "Insufficient backup implementation:  No AWS Backup plans found;  No backup execution data available for validation; \u2139 No EBS snapshots (acceptable if using AWS Backup exclusively)",
@@ -3324,10 +3589,11 @@
       "requirement": "Perform system backups aligned with recovery objectives",
       "remediated_at": "2025-09-20T05:19:49.833405Z",
       "remediation_commit": "cdd85e969c2ecde318d9922d77a2ac40244c01c1",
-      "duration_hours": 2.36
+      "duration_hours": 2.36,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2025-09-20T02:58:27.605038Z",
       "failed_commit": "2dba9071c9014058d890b6f1b2546034b1081dd0",
       "reason": "Insufficient recovery testing capability detected (0%): No recovery testing infrastructure found",
@@ -3336,10 +3602,11 @@
       "requirement": "Regularly test the capability to recover from incidents and contingencies",
       "remediated_at": "2025-09-20T05:19:49.833405Z",
       "remediation_commit": "cdd85e969c2ecde318d9922d77a2ac40244c01c1",
-      "duration_hours": 2.36
+      "duration_hours": 2.36,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
-      "ksi_id": "KSI-TPR-04",
+      "ksi_id": "KSI-SCR-MON",
       "failed_at": "2025-09-20T02:58:27.605038Z",
       "failed_commit": "2dba9071c9014058d890b6f1b2546034b1081dd0",
       "reason": "No third-party package vulnerability monitoring capability dete",
@@ -3348,10 +3615,11 @@
       "requirement": "Monitor third party software information resources for upstream vulnerabilities, with contractual notification requirements or active monitoring services",
       "remediated_at": "2025-09-20T05:19:49.833405Z",
       "remediation_commit": "cdd85e969c2ecde318d9922d77a2ac40244c01c1",
-      "duration_hours": 2.36
+      "duration_hours": 2.36,
+      "legacy_ksi_id": "KSI-TPR-04"
     },
     {
-      "ksi_id": "KSI-INR-03",
+      "ksi_id": "KSI-INR-AAR",
       "failed_at": "2025-09-15T21:53:18.762856Z",
       "failed_commit": "f0c1e74dab0ea6280a9282dfe550312d75e6493c",
       "reason": "No automated after action reporting infrastructure: No automated analysis capabilities detected",
@@ -3360,10 +3628,11 @@
       "requirement": "Generate after action reports and regularly incorporate lessons learned into operations",
       "remediated_at": "2025-09-20T07:54:45.093826Z",
       "remediation_commit": "18d901904796d7d9d23195c080d9e2a0ebf60de6",
-      "duration_hours": 106.02
+      "duration_hours": 106.02,
+      "legacy_ksi_id": "KSI-INR-03"
     },
     {
-      "ksi_id": "KSI-CED-03",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "No automated developer training infrastructure found: No training automation detected",
@@ -3372,10 +3641,11 @@
       "requirement": "Require role-specific training for development and engineering staff covering best practices for delivering secure software",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-CED-03"
     },
     {
-      "ksi_id": "KSI-CMT-01",
+      "ksi_id": "KSI-CMT-LMC",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "No system modification logging capability found (0%):  No CloudTrail trails found for system modification tracking; \u2139 AWS Config not configured (acceptable for low-impact pilot environments); \u2139 No CloudWatch log groups for application/system event logging; \u2139 No EventBridge rules for real-time change detection; \u2139 No CloudWatch alarms for modification monitoring; \u2139 No SNS topics for modification notifications; \u2139 No Lambda functions for automated modification response; \u2139 No SSM instances for instan",
@@ -3384,10 +3654,11 @@
       "requirement": "Log and monitor service modifications",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-CMT-01"
     },
     {
-      "ksi_id": "KSI-CMT-03",
+      "ksi_id": "KSI-CMT-VTD",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "No automated testing and validation infrastructure detected (8%):  Infrastructure validation: CloudFormation template testing capability",
@@ -3396,10 +3667,11 @@
       "requirement": "Implement persistent automated testing and validation of changes",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-CMT-03"
     },
     {
-      "ksi_id": "KSI-IAM-01",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "No centralized identity management detected:  No active AWS Identity Center - MFA enforcement unclear",
@@ -3408,10 +3680,11 @@
       "requirement": "Enforce multi-factor authentication (MFA) using methods that are difficult to intercept or impersonate (phishing-resistant MFA) for all user authentication",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-IAM-01"
     },
     {
-      "ksi_id": "KSI-IAM-02",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "Insufficient authentication security: \u2139 No SAML providers found;  No MFA devices configured;  No password policy configured (required when using passwords)",
@@ -3420,10 +3693,11 @@
       "requirement": "Use secure passwordless methods for user authentication and authorization when feasible, otherwise enforce strong passwords with MFA",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-IAM-02"
     },
     {
-      "ksi_id": "KSI-IAM-04",
+      "ksi_id": "KSI-IAM-JIT",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "Insufficient authorization model (0%): \u2139 IAM Identity Center not configured (using traditional IAM)",
@@ -3432,10 +3706,11 @@
       "requirement": "Use a least-privileged, role and attribute-based, and just-in-time security authorization model for all user and non-user accounts and services",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-IAM-04"
     },
     {
-      "ksi_id": "KSI-IAM-05",
+      "ksi_id": "KSI-IAM-ELP",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "Insufficient zero trust implementation (0%):  No IAM Identity Center - missing modern zero trust identity platform;  No MFA enforcement detected (zero trust requires multi-factor authentication);  Security group information not available;  Credential information not available;  No VPC endpoints found (consider private service access);  No CloudTrail monitoring configured",
@@ -3444,10 +3719,11 @@
       "requirement": "Design identity and access management systems that assume resources will be compromised",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-IAM-05"
     },
     {
-      "ksi_id": "KSI-IAM-07",
+      "ksi_id": "KSI-IAM-AAM",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "Insufficient account lifecycle management (0%):  User-heavy architecture: 0 roles vs 0 users; \u2139 No recent role modifications detected",
@@ -3456,10 +3732,11 @@
       "requirement": "Securely manage the lifecycle and privileges of all accounts, roles, and groups",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-IAM-07"
     },
     {
-      "ksi_id": "KSI-MLA-01",
+      "ksi_id": "KSI-MLA-OSM",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "Insufficient SIEM/centralized logging capabilities (6%):  No CloudTrail found - required for centralized logging;  No CloudWatch log groups found; \u2139 No CloudWatch alarms found for automated log analysis;  Security Hub available: Ready for advanced SIEM capabilities; \u2139 No Config delivery channels found for compliance log delivery",
@@ -3468,10 +3745,11 @@
       "requirement": "Operate a Security Information and Event Management (SIEM) or similar system(s) for centralized, tamper-resistant logging of events, activities, and changes",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-MLA-01"
     },
     {
-      "ksi_id": "KSI-MLA-05",
+      "ksi_id": "KSI-MLA-EVC",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "No Infrastructure as Code evaluation capability:  No CloudFormation stacks found for IaC evaluation;  No SSM parameters for centralized configuration management;  No Config rules for infrastructure evaluation; \u2139 No CI/CD automation (acceptable for Control Tower managed infrastructure)",
@@ -3480,10 +3758,11 @@
       "requirement": "Perform Infrastructure as Code and configuration evaluation and testing",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-MLA-05"
     },
     {
-      "ksi_id": "KSI-MLA-07",
+      "ksi_id": "KSI-MLA-LET",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "Insufficient automated monitoring inventory (0%):",
@@ -3492,10 +3771,11 @@
       "requirement": "Maintain a list of information resources and event types that will be monitored, logged, and audited",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-MLA-07"
     },
     {
-      "ksi_id": "KSI-MLA-08",
+      "ksi_id": "KSI-MLA-ALA",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "Insufficient RBAC log access control for Moderate baseline (0%):  No specialized log access roles identified",
@@ -3504,10 +3784,11 @@
       "requirement": "Use a least-privileged, role and attribute-based, and just-in-time access authorization model for access to log data",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-MLA-08"
     },
     {
-      "ksi_id": "KSI-PIY-01",
+      "ksi_id": "KSI-PIY-GIV",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "Insufficient comprehensive inventory of information resources (0%): No comprehensive resource discovery detected",
@@ -3516,10 +3797,11 @@
       "requirement": "Generate inventories of information resources from authoritative sources",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-PIY-01"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "Insufficient technical recovery capability for defined RTO/RPO objectives (0%): No recovery infrastructure or objectives detected",
@@ -3528,10 +3810,11 @@
       "requirement": "Define Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO)",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-SVC-08",
+      "ksi_id": "KSI-SVC-PRR",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "Insufficient change residual element management for Moderate baseline (0%):",
@@ -3540,10 +3823,11 @@
       "requirement": "Ensure that changes do not introduce or leave behind residual elements that could negatively affect confidentiality, integrity, or availability of information resources",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-SVC-08"
     },
     {
-      "ksi_id": "KSI-SVC-09",
+      "ksi_id": "KSI-SVC-VCM",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "Insufficient communication integrity validation for Moderate baseline (0%):",
@@ -3552,10 +3836,11 @@
       "requirement": "Use mechanisms that continuously validate the authenticity and integrity of communications between information resources",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-SVC-09"
     },
     {
-      "ksi_id": "KSI-SVC-10",
+      "ksi_id": "KSI-SVC-RUD",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "Insufficient automated data lifecycle management (25%):  Comprehensive log retention: 0/0 log groups with retention policies",
@@ -3564,7 +3849,8 @@
       "requirement": "Remove unwanted information promptly, including from backups if appropriate",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-SVC-10"
     },
     {
       "ksi_id": "KSI-TPR-01",
@@ -3576,10 +3862,12 @@
       "requirement": "Follow the requirements and recommendations in the FedRAMP Minimum Assessment Standard regarding third-party information resources",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-TPR-01",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-TPR-03",
+      "ksi_id": "KSI-SCR-MIT",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "No third-party services or mitigation policies identified via the compliance broker.",
@@ -3588,10 +3876,11 @@
       "requirement": "Identify and prioritize mitigation of potential supply chain risks",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-TPR-03"
     },
     {
-      "ksi_id": "KSI-TPR-04",
+      "ksi_id": "KSI-SCR-MON",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "No third-party package vulnerability monitoring capability dete",
@@ -3600,10 +3889,11 @@
       "requirement": "Monitor third party software information resources for upstream vulnerabilities, with contractual notification requirements or active monitoring services",
       "remediated_at": "2025-09-21T03:39:44.297426Z",
       "remediation_commit": "b5830f9fcf1928cae95f0923c2fc4e6de99ebf3b",
-      "duration_hours": 0.57
+      "duration_hours": 0.57,
+      "legacy_ksi_id": "KSI-TPR-04"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "Insufficient incident tracking (score: 0). Missing: need 2 more EventBridge rules with targets, need 4 more log groups with required retention. Found:  Permission denied for events;  Permission denied for events;  Permission denied for logs;  Permission denied for guardduty;  Permission denied for guardduty;  Permission denied for securityhub;  Permission denied for cloudtrail;  Permission denied for lambda",
@@ -3612,10 +3902,11 @@
       "requirement": "Maintain a log of incidents and periodically review past incidents for patterns or vulnerabilities",
       "remediated_at": "2025-09-21T08:11:55.437041Z",
       "remediation_commit": "5933a2204a037b7fe21fbc81ced95925c5078428",
-      "duration_hours": 5.11
+      "duration_hours": 5.11,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "Insufficient backup implementation:  No AWS Backup plans found;  No backup execution data available for validation; \u2139 No EBS snapshots (acceptable if using AWS Backup exclusively)",
@@ -3624,10 +3915,11 @@
       "requirement": "Perform system backups aligned with recovery objectives",
       "remediated_at": "2025-09-21T08:11:55.437041Z",
       "remediation_commit": "5933a2204a037b7fe21fbc81ced95925c5078428",
-      "duration_hours": 5.11
+      "duration_hours": 5.11,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2025-09-21T03:05:27.734939Z",
       "failed_commit": "95adac408e4248fbd36fd1daaa9d02183bc7dd42",
       "reason": "Insufficient recovery testing capability detected (0%): No recovery testing infrastructure found",
@@ -3636,10 +3928,11 @@
       "requirement": "Regularly test the capability to recover from incidents and contingencies",
       "remediated_at": "2025-09-21T08:11:55.437041Z",
       "remediation_commit": "5933a2204a037b7fe21fbc81ced95925c5078428",
-      "duration_hours": 5.11
+      "duration_hours": 5.11,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
-      "ksi_id": "KSI-PIY-04",
+      "ksi_id": "KSI-PIY-RSD",
       "failed_at": "2025-09-15T21:53:18.762856Z",
       "failed_commit": "f0c1e74dab0ea6280a9282dfe550312d75e6493c",
       "reason": "No SDLC security integration infrastructure: No development security automation detected",
@@ -3648,10 +3941,11 @@
       "requirement": "Build security considerations into SDLC and align with CISA Secure By Design principles",
       "remediated_at": "2025-09-22T14:25:56.600960Z",
       "remediation_commit": "8514fa3ec71e563802a12281f9757850bacad3b4",
-      "duration_hours": 160.54
+      "duration_hours": 160.54,
+      "legacy_ksi_id": "KSI-PIY-04"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2025-09-23T07:50:12.960932Z",
       "failed_commit": "326fc0213ed716d27c2b9b900393e81217ae9881",
       "reason": "Foundational failure: Incident response infrastructure is not adequately configured.  Incident response infrastructure may be incomplete (Score: 0/4).;  Operational log found with 1 incidents.;  Periodic review report found and appears valid.",
@@ -3660,10 +3954,11 @@
       "requirement": "Maintain a log of incidents and periodically review past incidents for patterns or vulnerabilities",
       "remediated_at": "2025-09-23T13:26:34.673541Z",
       "remediation_commit": "83ecb4babd804cc2f23cc7790f53770693f076a2",
-      "duration_hours": 5.61
+      "duration_hours": 5.61,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
-      "ksi_id": "KSI-CMT-03",
+      "ksi_id": "KSI-CMT-VTD",
       "failed_at": "2025-09-23T17:56:10.367968Z",
       "failed_commit": "c0a047729d464ceffc7358f58b9b8de748e4841b",
       "reason": "Exception during evaluation: 'str' object has no attribute 'get'",
@@ -3672,10 +3967,11 @@
       "requirement": "Implement persistent automated testing and validation of changes",
       "remediated_at": "2025-09-23T20:55:10.369976Z",
       "remediation_commit": "c7ece05f63ce09cd56d2765b60fa5896668031ff",
-      "duration_hours": 2.98
+      "duration_hours": 2.98,
+      "legacy_ksi_id": "KSI-CMT-03"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-09-23T07:50:12.960932Z",
       "failed_commit": "326fc0213ed716d27c2b9b900393e81217ae9881",
       "reason": "Exception during evaluation: 'list' object has no attribute 'get'",
@@ -3684,10 +3980,11 @@
       "requirement": "Define Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO)",
       "remediated_at": "2025-09-23T20:55:10.369976Z",
       "remediation_commit": "c7ece05f63ce09cd56d2765b60fa5896668031ff",
-      "duration_hours": 13.08
+      "duration_hours": 13.08,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-RPL-02",
+      "ksi_id": "KSI-RPL-ARP",
       "failed_at": "2025-09-23T17:56:10.367968Z",
       "failed_commit": "c0a047729d464ceffc7358f58b9b8de748e4841b",
       "reason": "No rule function found: evaluate_KSI_RPL_02",
@@ -3696,10 +3993,11 @@
       "requirement": "Develop and maintain a recovery plan that aligns with defined recovery objectives",
       "remediated_at": "2025-09-23T20:55:10.369976Z",
       "remediation_commit": "c7ece05f63ce09cd56d2765b60fa5896668031ff",
-      "duration_hours": 2.98
+      "duration_hours": 2.98,
+      "legacy_ksi_id": "KSI-RPL-02"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2025-09-23T20:55:10.369976Z",
       "failed_commit": "c7ece05f63ce09cd56d2765b60fa5896668031ff",
       "reason": "Foundational failure: Incident response infrastructure is not adequately configured.  Incident response infrastructure may be incomplete (Score: 0/4).;  Operational log found with 1 incidents.;  Periodic review report found and appears valid.",
@@ -3708,10 +4006,11 @@
       "requirement": "Maintain a log of incidents and periodically review past incidents for patterns or vulnerabilities",
       "remediated_at": "2025-09-23T21:16:09.227808Z",
       "remediation_commit": "5bfc7df5868bb9d3a3bf1647589df13ca1b0eebc",
-      "duration_hours": 0.35
+      "duration_hours": 0.35,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-09-23T20:55:10.369976Z",
       "failed_commit": "c7ece05f63ce09cd56d2765b60fa5896668031ff",
       "reason": "Insufficient backup implementation:  No AWS Backup plans found;  No backup execution data available for validation; \u2139 No EBS snapshots (acceptable if using AWS Backup exclusively)",
@@ -3720,10 +4019,11 @@
       "requirement": "Perform system backups aligned with recovery objectives",
       "remediated_at": "2025-09-23T21:16:09.227808Z",
       "remediation_commit": "5bfc7df5868bb9d3a3bf1647589df13ca1b0eebc",
-      "duration_hours": 0.35
+      "duration_hours": 0.35,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2025-09-23T20:55:10.369976Z",
       "failed_commit": "c7ece05f63ce09cd56d2765b60fa5896668031ff",
       "reason": "Insufficient recovery testing capability detected (0%): No recovery testing infrastructure found",
@@ -3732,10 +4032,11 @@
       "requirement": "Regularly test the capability to recover from incidents and contingencies",
       "remediated_at": "2025-09-23T21:16:09.227808Z",
       "remediation_commit": "5bfc7df5868bb9d3a3bf1647589df13ca1b0eebc",
-      "duration_hours": 0.35
+      "duration_hours": 0.35,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
-      "ksi_id": "KSI-CED-03",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-09-24T02:48:33.199989Z",
       "failed_commit": "891a8b31354138fa521517d8ecb5476e10be7b2c",
       "reason": "No automated developer training infrastructure found: No training automation detected",
@@ -3744,10 +4045,11 @@
       "requirement": "Require role-specific training for development and engineering staff covering best practices for delivering secure software",
       "remediated_at": "2025-09-24T04:35:09.683739Z",
       "remediation_commit": "9da4f7e29f63ad9dbc05107903b5990dbd8ae4f1",
-      "duration_hours": 1.78
+      "duration_hours": 1.78,
+      "legacy_ksi_id": "KSI-CED-03"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2025-09-24T02:48:33.199989Z",
       "failed_commit": "891a8b31354138fa521517d8ecb5476e10be7b2c",
       "reason": "Foundational failure: Incident response infrastructure is not adequately configured.  Incident response infrastructure may be incomplete (Score: 0/4).;  Operational log found with 1 incidents.;  Periodic review report found and appears valid.",
@@ -3756,10 +4058,11 @@
       "requirement": "Maintain a log of incidents and periodically review past incidents for patterns or vulnerabilities",
       "remediated_at": "2025-09-24T04:35:09.683739Z",
       "remediation_commit": "9da4f7e29f63ad9dbc05107903b5990dbd8ae4f1",
-      "duration_hours": 1.78
+      "duration_hours": 1.78,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
-      "ksi_id": "KSI-PIY-01",
+      "ksi_id": "KSI-PIY-GIV",
       "failed_at": "2025-09-24T02:48:33.199989Z",
       "failed_commit": "891a8b31354138fa521517d8ecb5476e10be7b2c",
       "reason": "Insufficient comprehensive inventory of information resources (0%): No comprehensive resource discovery detected",
@@ -3768,10 +4071,11 @@
       "requirement": "Generate inventories of information resources from authoritative sources",
       "remediated_at": "2025-09-24T04:35:09.683739Z",
       "remediation_commit": "9da4f7e29f63ad9dbc05107903b5990dbd8ae4f1",
-      "duration_hours": 1.78
+      "duration_hours": 1.78,
+      "legacy_ksi_id": "KSI-PIY-01"
     },
     {
-      "ksi_id": "KSI-PIY-04",
+      "ksi_id": "KSI-PIY-RSD",
       "failed_at": "2025-09-24T02:48:33.199989Z",
       "failed_commit": "891a8b31354138fa521517d8ecb5476e10be7b2c",
       "reason": "No SDLC security integration infrastructure: No development security automation detected",
@@ -3780,10 +4084,11 @@
       "requirement": "Build security and privacy considerations into the Software Development Lifecycle and align with CISA Secure By Design principles",
       "remediated_at": "2025-09-24T04:35:09.683739Z",
       "remediation_commit": "9da4f7e29f63ad9dbc05107903b5990dbd8ae4f1",
-      "duration_hours": 1.78
+      "duration_hours": 1.78,
+      "legacy_ksi_id": "KSI-PIY-04"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-09-24T02:48:33.199989Z",
       "failed_commit": "891a8b31354138fa521517d8ecb5476e10be7b2c",
       "reason": "Insufficient technical recovery capability (12%):  Backup vault configured.",
@@ -3792,10 +4097,11 @@
       "requirement": "Define Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO)",
       "remediated_at": "2025-09-24T04:35:09.683739Z",
       "remediation_commit": "9da4f7e29f63ad9dbc05107903b5990dbd8ae4f1",
-      "duration_hours": 1.78
+      "duration_hours": 1.78,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-09-24T02:48:33.199989Z",
       "failed_commit": "891a8b31354138fa521517d8ecb5476e10be7b2c",
       "reason": "Insufficient backup implementation:  No AWS Backup plans found;  No backup execution data available for validation; \u2139 No EBS snapshots (acceptable if using AWS Backup exclusively)",
@@ -3804,10 +4110,11 @@
       "requirement": "Perform system backups aligned with recovery objectives",
       "remediated_at": "2025-09-24T04:35:09.683739Z",
       "remediation_commit": "9da4f7e29f63ad9dbc05107903b5990dbd8ae4f1",
-      "duration_hours": 1.78
+      "duration_hours": 1.78,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2025-09-24T02:48:33.199989Z",
       "failed_commit": "891a8b31354138fa521517d8ecb5476e10be7b2c",
       "reason": "Insufficient recovery testing capability detected (0%): No recovery testing infrastructure found",
@@ -3816,7 +4123,8 @@
       "requirement": "Regularly test the capability to recover from incidents and contingencies",
       "remediated_at": "2025-09-24T04:35:09.683739Z",
       "remediation_commit": "9da4f7e29f63ad9dbc05107903b5990dbd8ae4f1",
-      "duration_hours": 1.78
+      "duration_hours": 1.78,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
       "ksi_id": "KSI-TPR-01",
@@ -3828,10 +4136,12 @@
       "requirement": "Follow the requirements and recommendations in the FedRAMP Minimum Assessment Standard regarding third-party information resources",
       "remediated_at": "2025-09-24T04:35:09.683739Z",
       "remediation_commit": "9da4f7e29f63ad9dbc05107903b5990dbd8ae4f1",
-      "duration_hours": 1.78
+      "duration_hours": 1.78,
+      "legacy_ksi_id": "KSI-TPR-01",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-TPR-03",
+      "ksi_id": "KSI-SCR-MIT",
       "failed_at": "2025-09-24T02:48:33.199989Z",
       "failed_commit": "891a8b31354138fa521517d8ecb5476e10be7b2c",
       "reason": "No third-party services or mitigation policies identified via the compliance broker.",
@@ -3840,10 +4150,11 @@
       "requirement": "Identify and prioritize mitigation of potential supply chain risks",
       "remediated_at": "2025-09-24T04:35:09.683739Z",
       "remediation_commit": "9da4f7e29f63ad9dbc05107903b5990dbd8ae4f1",
-      "duration_hours": 1.78
+      "duration_hours": 1.78,
+      "legacy_ksi_id": "KSI-TPR-03"
     },
     {
-      "ksi_id": "KSI-TPR-04",
+      "ksi_id": "KSI-SCR-MON",
       "failed_at": "2025-09-24T02:48:33.199989Z",
       "failed_commit": "891a8b31354138fa521517d8ecb5476e10be7b2c",
       "reason": "No third-party package vulnerability monitoring capability dete",
@@ -3852,10 +4163,11 @@
       "requirement": "Monitor third party software information resources for upstream vulnerabilities, with contractual notification requirements or active monitoring services",
       "remediated_at": "2025-09-24T04:35:09.683739Z",
       "remediation_commit": "9da4f7e29f63ad9dbc05107903b5990dbd8ae4f1",
-      "duration_hours": 1.78
+      "duration_hours": 1.78,
+      "legacy_ksi_id": "KSI-TPR-04"
     },
     {
-      "ksi_id": "KSI-SVC-10",
+      "ksi_id": "KSI-SVC-RUD",
       "failed_at": "2025-09-23T07:50:12.960932Z",
       "failed_commit": "326fc0213ed716d27c2b9b900393e81217ae9881",
       "reason": "Insufficient automated data lifecycle management (50%):  S3 Lifecycle Management;  Backup Retention Management;  Log Retention Policies;  Automated Cleanup Functions",
@@ -3864,10 +4176,11 @@
       "requirement": "Remove unwanted information promptly, including from backups if appropriate",
       "remediated_at": "2025-09-24T23:49:10.818749Z",
       "remediation_commit": "023cc959cbfacc3af1b263109b88f476791bd266",
-      "duration_hours": 39.98
+      "duration_hours": 39.98,
+      "legacy_ksi_id": "KSI-SVC-10"
     },
     {
-      "ksi_id": "KSI-CNA-04",
+      "ksi_id": "KSI-CNA-DFP",
       "failed_at": "2025-09-23T07:50:12.960932Z",
       "failed_commit": "326fc0213ed716d27c2b9b900393e81217ae9881",
       "reason": "CRITICAL least privilege violation detected: CRITICAL: The AdministratorAccess policy is attached to role(s): githubactions_role, OrganizationAccountAccessRole, AWSControlTowerExecution, stacksets-exec-d5e511141f10f5aa9846491550c31da6, SSM-CR-Execution-Role, aws-controltower-AdministratorExecutionRole, AWSReservedSSO_AdministratorAccess_500b4ab3fed23646.; CRITICAL: Security Group(s) expose sensitive ports to 0.0.0.0/0: launch-wizard-2 (Port: 22), launch-wizard-1 (Port: 22).",
@@ -3876,10 +4189,11 @@
       "requirement": "Use immutable infrastructure with strictly defined functionality and privileges by default",
       "remediated_at": "2025-09-25T19:26:49.871705Z",
       "remediation_commit": "eef80224385b09fff66e9536ea8894ff7926fc55",
-      "duration_hours": 59.61
+      "duration_hours": 59.61,
+      "legacy_ksi_id": "KSI-CNA-04"
     },
     {
-      "ksi_id": "KSI-CMT-03",
+      "ksi_id": "KSI-CMT-VTD",
       "failed_at": "2025-09-25T19:26:49.871705Z",
       "failed_commit": "eef80224385b09fff66e9536ea8894ff7926fc55",
       "reason": "No automated testing and validation infrastructure detected (0%):  IaC scan results artifact found (checkov_scan_summary.json).;  Automated testing proof artifact found (automated_testing_proof.json).",
@@ -3888,10 +4202,11 @@
       "requirement": "Implement persistent automated testing and validation of changes",
       "remediated_at": "2025-09-25T23:08:04.423814Z",
       "remediation_commit": "eaf31df00ed582f554dc9e1809f5d8787cfaa913",
-      "duration_hours": 3.69
+      "duration_hours": 3.69,
+      "legacy_ksi_id": "KSI-CMT-03"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2025-09-25T19:26:49.871705Z",
       "failed_commit": "eef80224385b09fff66e9536ea8894ff7926fc55",
       "reason": "Foundational failure: Incident response infrastructure is not adequately configured.  Incident response infrastructure may be incomplete (Score: 2/4).;  Operational log found with 1 incidents.;  Periodic review report found and appears valid.",
@@ -3900,10 +4215,11 @@
       "requirement": "Maintain a log of incidents and periodically review past incidents for patterns or vulnerabilities",
       "remediated_at": "2025-09-25T23:08:04.423814Z",
       "remediation_commit": "eaf31df00ed582f554dc9e1809f5d8787cfaa913",
-      "duration_hours": 3.69
+      "duration_hours": 3.69,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-09-25T19:26:49.871705Z",
       "failed_commit": "eef80224385b09fff66e9536ea8894ff7926fc55",
       "reason": "Insufficient technical recovery capability (38%):  Database backup capability: Retention up to 7 days.;  Point-in-time recovery: Enabled for 1/1 databases.;  Backup vault configured.",
@@ -3912,10 +4228,11 @@
       "requirement": "Define Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO)",
       "remediated_at": "2025-09-25T23:08:04.423814Z",
       "remediation_commit": "eaf31df00ed582f554dc9e1809f5d8787cfaa913",
-      "duration_hours": 3.69
+      "duration_hours": 3.69,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-SVC-08",
+      "ksi_id": "KSI-SVC-PRR",
       "failed_at": "2025-09-25T19:26:49.871705Z",
       "failed_commit": "eef80224385b09fff66e9536ea8894ff7926fc55",
       "reason": "Insufficient change residual element management (20%):  Infrastructure As Code;  Automated Cleanup;  Resource Lifecycle Management;  Residual Element Detection;  Change Impact Tracking",
@@ -3924,10 +4241,11 @@
       "requirement": "Ensure that changes do not introduce or leave behind residual elements that could negatively affect confidentiality, integrity, or availability of information resources",
       "remediated_at": "2025-09-25T23:08:04.423814Z",
       "remediation_commit": "eaf31df00ed582f554dc9e1809f5d8787cfaa913",
-      "duration_hours": 3.69
+      "duration_hours": 3.69,
+      "legacy_ksi_id": "KSI-SVC-08"
     },
     {
-      "ksi_id": "KSI-SVC-09",
+      "ksi_id": "KSI-SVC-VCM",
       "failed_at": "2025-09-25T19:26:49.871705Z",
       "failed_commit": "eef80224385b09fff66e9536ea8894ff7926fc55",
       "reason": "Insufficient communication integrity validation (40%):  Tls Certificate Management;  Continuous Certificate Monitoring;  Inter Service Encryption;  Integrity Validation Mechanisms;  Automated Certificate Lifecycle",
@@ -3936,10 +4254,11 @@
       "requirement": "Use mechanisms that continuously validate the authenticity and integrity of communications between information resources",
       "remediated_at": "2025-09-25T23:08:04.423814Z",
       "remediation_commit": "eaf31df00ed582f554dc9e1809f5d8787cfaa913",
-      "duration_hours": 3.69
+      "duration_hours": 3.69,
+      "legacy_ksi_id": "KSI-SVC-09"
     },
     {
-      "ksi_id": "KSI-SVC-10",
+      "ksi_id": "KSI-SVC-RUD",
       "failed_at": "2025-09-25T19:26:49.871705Z",
       "failed_commit": "eef80224385b09fff66e9536ea8894ff7926fc55",
       "reason": "Insufficient automated data lifecycle management (50%):  S3 Lifecycle Management;  Backup Retention Management;  Log Retention Policies;  Automated Cleanup Functions",
@@ -3948,7 +4267,8 @@
       "requirement": "Remove unwanted information promptly, including from backups if appropriate",
       "remediated_at": "2025-09-25T23:08:04.423814Z",
       "remediation_commit": "eaf31df00ed582f554dc9e1809f5d8787cfaa913",
-      "duration_hours": 3.69
+      "duration_hours": 3.69,
+      "legacy_ksi_id": "KSI-SVC-10"
     },
     {
       "ksi_id": "KSI-TPR-01",
@@ -3960,10 +4280,12 @@
       "requirement": "Follow the requirements and recommendations in the FedRAMP Minimum Assessment Standard regarding third-party information resources",
       "remediated_at": "2025-09-25T23:08:04.423814Z",
       "remediation_commit": "eaf31df00ed582f554dc9e1809f5d8787cfaa913",
-      "duration_hours": 3.69
+      "duration_hours": 3.69,
+      "legacy_ksi_id": "KSI-TPR-01",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-TPR-03",
+      "ksi_id": "KSI-SCR-MIT",
       "failed_at": "2025-09-25T19:26:49.871705Z",
       "failed_commit": "eef80224385b09fff66e9536ea8894ff7926fc55",
       "reason": "No third-party services or mitigation policies identified via the compliance broker.",
@@ -3972,10 +4294,11 @@
       "requirement": "Identify and prioritize mitigation of potential supply chain risks",
       "remediated_at": "2025-09-25T23:08:04.423814Z",
       "remediation_commit": "eaf31df00ed582f554dc9e1809f5d8787cfaa913",
-      "duration_hours": 3.69
+      "duration_hours": 3.69,
+      "legacy_ksi_id": "KSI-TPR-03"
     },
     {
-      "ksi_id": "KSI-TPR-04",
+      "ksi_id": "KSI-SCR-MON",
       "failed_at": "2025-09-25T19:26:49.871705Z",
       "failed_commit": "eef80224385b09fff66e9536ea8894ff7926fc55",
       "reason": "No third-party package vulnerability monitoring capability dete",
@@ -3984,10 +4307,11 @@
       "requirement": "Monitor third party software information resources for upstream vulnerabilities, with contractual notification requirements or active monitoring services",
       "remediated_at": "2025-09-25T23:08:04.423814Z",
       "remediation_commit": "eaf31df00ed582f554dc9e1809f5d8787cfaa913",
-      "duration_hours": 3.69
+      "duration_hours": 3.69,
+      "legacy_ksi_id": "KSI-TPR-04"
     },
     {
-      "ksi_id": "KSI-CNA-06",
+      "ksi_id": "KSI-CNA-OFA",
       "failed_at": "2025-10-01T03:22:32.099963Z",
       "failed_commit": "48dad3e8b096d2c79b65a0212b99f7e608a04f24",
       "reason": "Exception during evaluation: name 'compliance_percentage' is not defined",
@@ -3996,10 +4320,11 @@
       "requirement": "Design systems for high availability and rapid recovery",
       "remediated_at": "2025-10-01T06:31:38.418216Z",
       "remediation_commit": "0b2a96886c662c4121dae65068389a335afea3f7",
-      "duration_hours": 3.15
+      "duration_hours": 3.15,
+      "legacy_ksi_id": "KSI-CNA-06"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-10-01T03:22:32.099963Z",
       "failed_commit": "48dad3e8b096d2c79b65a0212b99f7e608a04f24",
       "reason": "Exception during evaluation: name 'compliance_percentage' is not defined",
@@ -4008,10 +4333,11 @@
       "requirement": "Define Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO)",
       "remediated_at": "2025-10-01T06:31:38.418216Z",
       "remediation_commit": "0b2a96886c662c4121dae65068389a335afea3f7",
-      "duration_hours": 3.15
+      "duration_hours": 3.15,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-10-01T06:31:38.418216Z",
       "failed_commit": "0b2a96886c662c4121dae65068389a335afea3f7",
       "reason": "Exception during evaluation: '>' not supported between instances of 'str' and 'int'",
@@ -4020,10 +4346,11 @@
       "requirement": "Perform system backups aligned with recovery objectives",
       "remediated_at": "2025-10-01T08:13:08.502681Z",
       "remediation_commit": "c5fd633bc5994c092d17c47d05d9445afd85df57",
-      "duration_hours": 1.69
+      "duration_hours": 1.69,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-CNA-04",
+      "ksi_id": "KSI-CNA-DFP",
       "failed_at": "2025-10-01T06:31:38.418216Z",
       "failed_commit": "0b2a96886c662c4121dae65068389a335afea3f7",
       "reason": "Exception during evaluation: 1",
@@ -4032,10 +4359,11 @@
       "requirement": "Use immutable infrastructure with strictly defined functionality and privileges by default",
       "remediated_at": "2025-10-01T22:14:35.220348Z",
       "remediation_commit": "697e250c153e5604aa7cc05c6d897ea1e11e2ffb",
-      "duration_hours": 15.72
+      "duration_hours": 15.72,
+      "legacy_ksi_id": "KSI-CNA-04"
     },
     {
-      "ksi_id": "KSI-CNA-05",
+      "ksi_id": "KSI-CNA-RVP",
       "failed_at": "2025-10-01T03:22:32.099963Z",
       "failed_commit": "48dad3e8b096d2c79b65a0212b99f7e608a04f24",
       "reason": "Insufficient protection against DDoS and/or Spam (50%):  Network-layer protection: AWS Shield Standard is automatically enabled.;  Application-layer protection: 1 Regional WAF(s) found.;  Service resilience: Multi-AZ load balancers are in use.;  DNS protection: 1 Route 53 hosted zone(s) provide managed DNS.",
@@ -4044,10 +4372,11 @@
       "requirement": "Protect against denial of service attacks and unwanted spam",
       "remediated_at": "2025-10-01T22:14:35.220348Z",
       "remediation_commit": "697e250c153e5604aa7cc05c6d897ea1e11e2ffb",
-      "duration_hours": 18.87
+      "duration_hours": 18.87,
+      "legacy_ksi_id": "KSI-CNA-05"
     },
     {
-      "ksi_id": "KSI-IAM-01",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2025-09-25T19:26:49.871705Z",
       "failed_commit": "eef80224385b09fff66e9536ea8894ff7926fc55",
       "reason": "No centralized identity management detected:  No active AWS Identity Center - MFA enforcement unclear",
@@ -4056,10 +4385,11 @@
       "requirement": "Enforce multi-factor authentication (MFA) using methods that are difficult to intercept or impersonate (phishing-resistant MFA) for all user authentication",
       "remediated_at": "2025-10-01T22:14:35.220348Z",
       "remediation_commit": "697e250c153e5604aa7cc05c6d897ea1e11e2ffb",
-      "duration_hours": 146.8
+      "duration_hours": 146.8,
+      "legacy_ksi_id": "KSI-IAM-01"
     },
     {
-      "ksi_id": "KSI-PIY-06",
+      "ksi_id": "KSI-PIY-RIS",
       "failed_at": "2025-09-26T17:30:49.769423Z",
       "failed_commit": "7d1b4d923570a3721323b3a07c98768daa7018f3",
       "reason": "No rule function found: evaluate_KSI_PIY_06",
@@ -4068,10 +4398,11 @@
       "requirement": "Have staff and budget for security commensurate with the size, complexity, scope, executive priorities, and risk of the service offering that demonstrates commitment to delivering a secure service",
       "remediated_at": "2025-10-01T22:14:35.220348Z",
       "remediation_commit": "697e250c153e5604aa7cc05c6d897ea1e11e2ffb",
-      "duration_hours": 124.73
+      "duration_hours": 124.73,
+      "legacy_ksi_id": "KSI-PIY-06"
     },
     {
-      "ksi_id": "KSI-CNA-08",
+      "ksi_id": "KSI-CNA-EIS",
       "failed_at": "2025-10-01T03:22:32.099963Z",
       "failed_commit": "48dad3e8b096d2c79b65a0212b99f7e608a04f24",
       "reason": "Insufficient continuous security assessment for Moderate baseline (33%):  Automated remediation: 2 security automation functions",
@@ -4080,7 +4411,8 @@
       "requirement": "Use automated services to persistently assess the security posture of all services and automatically enforce secure operations",
       "remediated_at": "2025-10-02T03:01:52.404434Z",
       "remediation_commit": "ce68de6a4f8ae6f60d56ba45893def0a23669281",
-      "duration_hours": 23.66
+      "duration_hours": 23.66,
+      "legacy_ksi_id": "KSI-CNA-08"
     },
     {
       "ksi_id": "KSI-PIY-02",
@@ -4092,7 +4424,9 @@
       "requirement": "Document the security objectives and requirements for each information resource",
       "remediated_at": "2025-10-10T03:07:18.435901Z",
       "remediation_commit": "8ad66bdb200edaaee7ff53940805f0f3ccf1c7d1",
-      "duration_hours": 6.49
+      "duration_hours": 6.49,
+      "legacy_ksi_id": "KSI-PIY-02",
+      "retired_pre_cr26": true
     },
     {
       "ksi_id": "KSI-PIY-05",
@@ -4104,7 +4438,9 @@
       "requirement": "Document methods used to evaluate information resource implementations",
       "remediated_at": "2025-10-10T03:07:18.435901Z",
       "remediation_commit": "8ad66bdb200edaaee7ff53940805f0f3ccf1c7d1",
-      "duration_hours": 6.49
+      "duration_hours": 6.49,
+      "legacy_ksi_id": "KSI-PIY-05",
+      "retired_pre_cr26": true
     },
     {
       "ksi_id": "KSI-PIY-07",
@@ -4116,10 +4452,12 @@
       "requirement": "Document risk management decisions for software supply chain security",
       "remediated_at": "2025-10-10T03:07:18.435901Z",
       "remediation_commit": "8ad66bdb200edaaee7ff53940805f0f3ccf1c7d1",
-      "duration_hours": 6.49
+      "duration_hours": 6.49,
+      "legacy_ksi_id": "KSI-PIY-07",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-PIY-03",
+      "ksi_id": "KSI-PIY-RVD",
       "failed_at": "2025-10-09T20:38:11.215808Z",
       "failed_commit": "845d2d36606192590b775d105f46e7dd1167c6d2",
       "reason": "No vulnerability disclosure program detected (1/14):  Legacy VDP documentation - migrate to CodeCommit",
@@ -4128,10 +4466,11 @@
       "requirement": "Maintain a vulnerability disclosure program",
       "remediated_at": "2025-10-11T03:05:08.777432Z",
       "remediation_commit": "cff1a7a41ed615785cbbc74711b76ecc61035c38",
-      "duration_hours": 30.45
+      "duration_hours": 30.45,
+      "legacy_ksi_id": "KSI-PIY-03"
     },
     {
-      "ksi_id": "KSI-CNA-05",
+      "ksi_id": "KSI-CNA-RVP",
       "failed_at": "2025-10-09T03:05:53.766779Z",
       "failed_commit": "9127d3af9b58d3accfc2e024ca26fea3740aee52",
       "reason": "Insufficient DDoS and spam protection (50%):  Network-layer protection: AWS Shield Standard automatically enabled (all AWS accounts);  Application-layer protection: 1 Regional WAF Web ACL(s) configured;  Service resilience: 1 Multi-AZ load balancer(s) configured;  SES identities exist but not verified;  Missing email authentication: SPF, DMARC, DKIM",
@@ -4140,10 +4479,11 @@
       "requirement": "Protect against denial of service attacks and unwanted spam",
       "remediated_at": "2025-10-12T03:08:36.669011Z",
       "remediation_commit": "1aa8267076a34a6dbd6ebfb2d6b95809c80b3aa3",
-      "duration_hours": 72.05
+      "duration_hours": 72.05,
+      "legacy_ksi_id": "KSI-CNA-05"
     },
     {
-      "ksi_id": "KSI-INR-01",
+      "ksi_id": "KSI-INR-RIR",
       "failed_at": "2025-10-09T20:38:11.215808Z",
       "failed_commit": "845d2d36606192590b775d105f46e7dd1167c6d2",
       "reason": "Insufficient FedRAMP incident response (2/11):  Security Hub integrated: 0 findings tracked;  Security Hub integrated: 10 findings tracked;  Legacy incident procedures - migrate to CodeCommit",
@@ -4152,10 +4492,11 @@
       "requirement": "Respond to incidents according to FedRAMP requirements and cloud service provider policies",
       "remediated_at": "2025-10-12T03:08:36.669011Z",
       "remediation_commit": "1aa8267076a34a6dbd6ebfb2d6b95809c80b3aa3",
-      "duration_hours": 54.51
+      "duration_hours": 54.51,
+      "legacy_ksi_id": "KSI-INR-01"
     },
     {
-      "ksi_id": "KSI-IAM-04",
+      "ksi_id": "KSI-IAM-JIT",
       "failed_at": "2025-10-12T03:08:36.669011Z",
       "failed_commit": "1aa8267076a34a6dbd6ebfb2d6b95809c80b3aa3",
       "reason": "Exception during evaluation: name 're' is not defined",
@@ -4164,7 +4505,8 @@
       "requirement": "Use a least-privileged, role and attribute-based, and just-in-time security authorization model for all user and non-user accounts and services",
       "remediated_at": "2025-10-12T08:31:06.460463Z",
       "remediation_commit": "44028658725533344da15a206e03a4369f3827db",
-      "duration_hours": 5.37
+      "duration_hours": 5.37,
+      "legacy_ksi_id": "KSI-IAM-04"
     },
     {
       "ksi_id": "KSI-PIY-05",
@@ -4176,10 +4518,12 @@
       "requirement": "Document methods used to evaluate information resource implementations",
       "remediated_at": "2025-10-12T08:31:06.460463Z",
       "remediation_commit": "44028658725533344da15a206e03a4369f3827db",
-      "duration_hours": 5.37
+      "duration_hours": 5.37,
+      "legacy_ksi_id": "KSI-PIY-05",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-SVC-09",
+      "ksi_id": "KSI-SVC-VCM",
       "failed_at": "2025-10-12T03:08:36.669011Z",
       "failed_commit": "1aa8267076a34a6dbd6ebfb2d6b95809c80b3aa3",
       "reason": "Exception during evaluation: 'list' object has no attribute 'get'",
@@ -4188,10 +4532,11 @@
       "requirement": "Use mechanisms that continuously validate the authenticity and integrity of communications between information resources",
       "remediated_at": "2025-10-12T08:31:06.460463Z",
       "remediation_commit": "44028658725533344da15a206e03a4369f3827db",
-      "duration_hours": 5.37
+      "duration_hours": 5.37,
+      "legacy_ksi_id": "KSI-SVC-09"
     },
     {
-      "ksi_id": "KSI-CMT-04",
+      "ksi_id": "KSI-CMT-RVP",
       "failed_at": "2025-09-29T22:00:57.216908Z",
       "failed_commit": "5fc6812a2e9cd62191afd6ffb5a3c443212c7213",
       "reason": "No rule function found: evaluate_KSI_CMT_04",
@@ -4200,7 +4545,8 @@
       "requirement": "Consistently follow a documented change management procedure",
       "remediated_at": "2025-10-12T12:35:01.593944Z",
       "remediation_commit": "a0598f46eac0c203049fffa4b5b65ac4abd87440",
-      "duration_hours": 302.57
+      "duration_hours": 302.57,
+      "legacy_ksi_id": "KSI-CMT-04"
     },
     {
       "ksi_id": "KSI-CMT-05",
@@ -4212,10 +4558,12 @@
       "requirement": "Evaluate the risk and potential impact of any change",
       "remediated_at": "2025-10-12T12:35:01.593944Z",
       "remediation_commit": "a0598f46eac0c203049fffa4b5b65ac4abd87440",
-      "duration_hours": 273.21
+      "duration_hours": 273.21,
+      "legacy_ksi_id": "KSI-CMT-05",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-IAM-01",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2025-10-12T03:08:36.669011Z",
       "failed_commit": "1aa8267076a34a6dbd6ebfb2d6b95809c80b3aa3",
       "reason": "Exception during evaluation: 'str' object has no attribute 'get'",
@@ -4224,7 +4572,8 @@
       "requirement": "Enforce multi-factor authentication (MFA) using methods that are difficult to intercept or impersonate (phishing-resistant MFA) for all user authentication",
       "remediated_at": "2025-10-13T21:06:13.049163Z",
       "remediation_commit": "7fa3d16e83e68fc728f885091f10af7759bb5f74",
-      "duration_hours": 41.96
+      "duration_hours": 41.96,
+      "legacy_ksi_id": "KSI-IAM-01"
     },
     {
       "ksi_id": "KSI-PIY-07",
@@ -4236,10 +4585,12 @@
       "requirement": "Document risk management decisions for software supply chain security",
       "remediated_at": "2025-10-13T21:06:13.049163Z",
       "remediation_commit": "7fa3d16e83e68fc728f885091f10af7759bb5f74",
-      "duration_hours": 41.96
+      "duration_hours": 41.96,
+      "legacy_ksi_id": "KSI-PIY-07",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-TPR-03",
+      "ksi_id": "KSI-SCR-MIT",
       "failed_at": "2025-10-09T20:38:11.215808Z",
       "failed_commit": "845d2d36606192590b775d105f46e7dd1167c6d2",
       "reason": "Insufficient supply chain risk management (-1/13):  Legacy SSM policies detected - migration recommended",
@@ -4248,10 +4599,11 @@
       "requirement": "Identify and prioritize mitigation of potential supply chain risks",
       "remediated_at": "2025-10-13T21:06:13.049163Z",
       "remediation_commit": "7fa3d16e83e68fc728f885091f10af7759bb5f74",
-      "duration_hours": 96.47
+      "duration_hours": 96.47,
+      "legacy_ksi_id": "KSI-TPR-03"
     },
     {
-      "ksi_id": "KSI-IAM-03",
+      "ksi_id": "KSI-IAM-SNU",
       "failed_at": "2025-10-12T03:08:36.669011Z",
       "failed_commit": "1aa8267076a34a6dbd6ebfb2d6b95809c80b3aa3",
       "reason": "Exception during evaluation: 'str' object has no attribute 'get'",
@@ -4260,10 +4612,11 @@
       "requirement": "Enforce appropriately secure authentication methods for non-user accounts and services",
       "remediated_at": "2025-10-14T00:47:00.355073Z",
       "remediation_commit": "d7da1a04b193f3150e59000c79cea78632f2c793",
-      "duration_hours": 45.64
+      "duration_hours": 45.64,
+      "legacy_ksi_id": "KSI-IAM-03"
     },
     {
-      "ksi_id": "KSI-CNA-04",
+      "ksi_id": "KSI-CNA-DFP",
       "failed_at": "2025-10-12T03:08:36.669011Z",
       "failed_commit": "1aa8267076a34a6dbd6ebfb2d6b95809c80b3aa3",
       "reason": "Immediate failure due to critical security violations: CRITICAL: IAM Users have AdministratorAccess: Terraform, change_template_approver. Use roles instead.; CRITICAL: Non-standard roles have AdministratorAccess: stacksets-exec-d5e511141f10f5aa9846491550c31da6.",
@@ -4272,10 +4625,11 @@
       "requirement": "Use immutable infrastructure with strictly defined functionality and privileges by default",
       "remediated_at": "2025-10-14T04:10:51.004385Z",
       "remediation_commit": "33eae84c400269769cec1224d60cc2b2b40842e1",
-      "duration_hours": 49.04
+      "duration_hours": 49.04,
+      "legacy_ksi_id": "KSI-CNA-04"
     },
     {
-      "ksi_id": "KSI-IAM-01",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2025-10-14T00:47:00.355073Z",
       "failed_commit": "d7da1a04b193f3150e59000c79cea78632f2c793",
       "reason": "Exception during evaluation: 'dict' object has no attribute 'splitlines'",
@@ -4284,10 +4638,11 @@
       "requirement": "Enforce multi-factor authentication (MFA) using methods that are difficult to intercept or impersonate (phishing-resistant MFA) for all user authentication",
       "remediated_at": "2025-10-14T04:10:51.004385Z",
       "remediation_commit": "33eae84c400269769cec1224d60cc2b2b40842e1",
-      "duration_hours": 3.4
+      "duration_hours": 3.4,
+      "legacy_ksi_id": "KSI-IAM-01"
     },
     {
-      "ksi_id": "KSI-IAM-05",
+      "ksi_id": "KSI-IAM-ELP",
       "failed_at": "2025-10-12T03:08:36.669011Z",
       "failed_commit": "1aa8267076a34a6dbd6ebfb2d6b95809c80b3aa3",
       "reason": "Critical Zero Trust Gaps Detected (40%):  [Identity] No IAM Identity Center found. A modern identity platform is a core tenant of Zero Trust.;  [Segmentation] Excellent network micro-segmentation: No security groups have overly permissive inbound rules.;  [Credentials] Best practice followed: Using temporary, session-based credentials (assumed role).;  [Secure Communications] Comprehensive private networking with 7 VPC endpoints.;  [Monitoring] CRITICAL GAP: No CloudTrail configured for monitori",
@@ -4296,10 +4651,11 @@
       "requirement": "Design identity and access management systems that assume resources will be compromised",
       "remediated_at": "2025-10-14T04:10:51.004385Z",
       "remediation_commit": "33eae84c400269769cec1224d60cc2b2b40842e1",
-      "duration_hours": 49.04
+      "duration_hours": 49.04,
+      "legacy_ksi_id": "KSI-IAM-05"
     },
     {
-      "ksi_id": "KSI-IAM-07",
+      "ksi_id": "KSI-IAM-AAM",
       "failed_at": "2025-10-14T00:47:00.355073Z",
       "failed_commit": "d7da1a04b193f3150e59000c79cea78632f2c793",
       "reason": "Insufficient account lifecycle management (40%):  Service Oriented Architecture;  Active Lifecycle Management;  Privilege Automation;  Automated Provisioning;  Regular Access Reviews",
@@ -4308,10 +4664,11 @@
       "requirement": "Securely manage the lifecycle and privileges of all accounts, roles, and groups",
       "remediated_at": "2025-10-14T04:10:51.004385Z",
       "remediation_commit": "33eae84c400269769cec1224d60cc2b2b40842e1",
-      "duration_hours": 3.4
+      "duration_hours": 3.4,
+      "legacy_ksi_id": "KSI-IAM-07"
     },
     {
-      "ksi_id": "KSI-CNA-04",
+      "ksi_id": "KSI-CNA-DFP",
       "failed_at": "2025-10-14T15:45:13.237428Z",
       "failed_commit": "f652f2e6e73af2d1c46753e5ed0bc3efee718610",
       "reason": "Immediate failure due to critical security violations: CRITICAL: User-created roles have AdministratorAccess: githubactions_role (User-created role).",
@@ -4320,7 +4677,8 @@
       "requirement": "Use immutable infrastructure with strictly defined functionality and privileges by default",
       "remediated_at": "2025-10-14T18:40:19.682172Z",
       "remediation_commit": "b31e74a6985ce082ad2eb9252805dbba484b630d",
-      "duration_hours": 2.92
+      "duration_hours": 2.92,
+      "legacy_ksi_id": "KSI-CNA-04"
     },
     {
       "ksi_id": "KSI-CMT-05",
@@ -4332,10 +4690,12 @@
       "requirement": "Evaluate the risk and potential impact of any change",
       "remediated_at": "2025-10-15T05:00:22.729749Z",
       "remediation_commit": "dac9355a1b7004d4b93f3091267a02ada47ed575",
-      "duration_hours": 10.33
+      "duration_hours": 10.33,
+      "legacy_ksi_id": "KSI-CMT-05",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-CNA-08",
+      "ksi_id": "KSI-CNA-EIS",
       "failed_at": "2025-10-20T12:50:27.130054Z",
       "failed_commit": "932e289eafb0082a8299c4de4dc818a059d4081c",
       "reason": "No active measurement capability (42%): Basic framework: 1 Security Hub standard(s); No measurement instruments (Config rules not deployed); Active measurement: Config recorder capturing data; Limited visibility: No central aggregation",
@@ -4344,10 +4704,11 @@
       "requirement": "Use automated services to persistently assess the security posture of all services and automatically enforce secure operations",
       "remediated_at": "2025-10-20T18:52:17.574057Z",
       "remediation_commit": "8229e31c996677d62a8350358738565e0f215901",
-      "duration_hours": 6.03
+      "duration_hours": 6.03,
+      "legacy_ksi_id": "KSI-CNA-08"
     },
     {
-      "ksi_id": "KSI-CNA-01",
+      "ksi_id": "KSI-CNA-RNT",
       "failed_at": "2025-10-24T03:00:14.583575Z",
       "failed_commit": "250ebd06e74922e10ef7571f3817e85fde94ba9d",
       "reason": "Below threshold: 5/16 (31.2%) - requires 50.0% for LOW impact:  VPC infrastructure: 1 VPC(s) detected;  Strong ingress controls: 15/15 security groups restrictive;  Strong egress controls: 14/15 security groups control outbound traffic;  Default security group properly secured;  Custom network controls: 1/1 Network ACLs with custom traffic filtering rules;  Controlled egress routing: 1 private route tables with NAT gateway routing;  Managed egress: 1 NAT gateways for controlled outbound access; ",
@@ -4356,10 +4717,11 @@
       "requirement": "Configure ALL machine-based information resources to limit inbound and outbound traffic",
       "remediated_at": "2025-11-02T01:09:44-06:00",
       "remediation_commit": "872a80acc3f445392407d7f72bb55b7478d84620",
-      "duration_hours": 220.16
+      "duration_hours": 220.16,
+      "legacy_ksi_id": "KSI-CNA-01"
     },
     {
-      "ksi_id": "KSI-PIY-03",
+      "ksi_id": "KSI-PIY-RVD",
       "failed_at": "2025-10-12T03:08:36.669011Z",
       "failed_commit": "1aa8267076a34a6dbd6ebfb2d6b95809c80b3aa3",
       "reason": "No vulnerability disclosure program detected (1/14):  VDP maintenance activity: 1 updates",
@@ -4368,10 +4730,11 @@
       "requirement": "Maintain a vulnerability disclosure program",
       "remediated_at": "2025-11-02T01:09:44-06:00",
       "remediation_commit": "872a80acc3f445392407d7f72bb55b7478d84620",
-      "duration_hours": 508.02
+      "duration_hours": 508.02,
+      "legacy_ksi_id": "KSI-PIY-03"
     },
     {
-      "ksi_id": "KSI-CED-03",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-11-02T01:09:44-06:00",
       "failed_commit": "872a80acc3f445392407d7f72bb55b7478d84620",
       "reason": "Insufficient 2/7 (29%):  Development security automation: Found 2 potentially security-related Lambda function(s).;  EventBridge rule data unavailable.",
@@ -4380,10 +4743,11 @@
       "requirement": "Require role-specific training for development and engineering staff covering best practices for delivering secure software",
       "remediated_at": "2025-11-02T07:21:10.830697Z",
       "remediation_commit": "3cca6f4e709b257aac726748a97f96a834749489",
-      "duration_hours": 0.19
+      "duration_hours": 0.19,
+      "legacy_ksi_id": "KSI-CED-03"
     },
     {
-      "ksi_id": "KSI-CNA-04",
+      "ksi_id": "KSI-CNA-DFP",
       "failed_at": "2025-11-02T01:09:44-06:00",
       "failed_commit": "872a80acc3f445392407d7f72bb55b7478d84620",
       "reason": "Below threshold: 7/12 (58.3%) - requires 64.0% for MODERATE impact:  Least Privilege: AdministratorAccess is properly restricted to AWS-managed infrastructure roles.;  Network Security: No sensitive ports are exposed to the internet.;  Foundational IaC: No direct Terraform state/lock evidence found, but resources exist (may use CloudFormation or other IaC).;  Serverless Adoption: 19 Lambda functions are in use (inherently immutable).;  EC2 Standardization: No Launch Templates found for 5 running",
@@ -4392,10 +4756,11 @@
       "requirement": "Use immutable infrastructure with strictly defined privileges",
       "remediated_at": "2025-11-02T07:21:10.830697Z",
       "remediation_commit": "3cca6f4e709b257aac726748a97f96a834749489",
-      "duration_hours": 0.19
+      "duration_hours": 0.19,
+      "legacy_ksi_id": "KSI-CNA-04"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2025-11-02T01:09:44-06:00",
       "failed_commit": "872a80acc3f445392407d7f72bb55b7478d84620",
       "reason": "Insufficient 4/15 (27%):  Backup infrastructure validated: 50 successful backup jobs found within the last 7 days.;  Point-in-time recovery testing capability: 1/1 databases have PITR enabled (LatestRestorableTime).; \u2139 Recovery test tracking parameter found, but value is 'Not configured'.",
@@ -4404,10 +4769,11 @@
       "requirement": "Regularly test the capability to recover from incidents and contingencies",
       "remediated_at": "2025-11-02T07:21:10.830697Z",
       "remediation_commit": "3cca6f4e709b257aac726748a97f96a834749489",
-      "duration_hours": 0.19
+      "duration_hours": 0.19,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
-      "ksi_id": "KSI-CNA-01",
+      "ksi_id": "KSI-CNA-RNT",
       "failed_at": "2025-11-02T07:21:10.830697Z",
       "failed_commit": "3cca6f4e709b257aac726748a97f96a834749489",
       "reason": "Below threshold: 5/16 (31.2%) - requires 50.0% for LOW impact:  VPC infrastructure: 1 VPC(s) detected;  Strong ingress controls: 15/15 security groups restrictive;  Strong egress controls: 14/15 security groups control outbound traffic;  Default security group properly secured;  Custom network controls: 1/1 Network ACLs with custom traffic filtering rules;  Controlled egress routing: 1 private route tables with NAT gateway routing;  Managed egress: 1 NAT gateways for controlled outbound access; ",
@@ -4416,10 +4782,11 @@
       "requirement": "Configure ALL machine-based information resources to limit inbound and outbound traffic",
       "remediated_at": "2025-11-04T11:47:03-07:00",
       "remediation_commit": "898829eddf09f7bc3717b880ff22b578280134f1",
-      "duration_hours": 59.43
+      "duration_hours": 59.43,
+      "legacy_ksi_id": "KSI-CNA-01"
     },
     {
-      "ksi_id": "KSI-PIY-03",
+      "ksi_id": "KSI-PIY-RVD",
       "failed_at": "2025-11-02T07:21:10.830697Z",
       "failed_commit": "3cca6f4e709b257aac726748a97f96a834749489",
       "reason": "No vulnerability disclosure program detected (1/14):  VDP maintenance activity: 1 updates",
@@ -4428,10 +4795,11 @@
       "requirement": "Maintain a vulnerability disclosure program",
       "remediated_at": "2025-11-04T11:47:03-07:00",
       "remediation_commit": "898829eddf09f7bc3717b880ff22b578280134f1",
-      "duration_hours": 59.43
+      "duration_hours": 59.43,
+      "legacy_ksi_id": "KSI-PIY-03"
     },
     {
-      "ksi_id": "KSI-CED-03",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-11-04T11:47:03-07:00",
       "failed_commit": "898829eddf09f7bc3717b880ff22b578280134f1",
       "reason": "Insufficient 2/7 (29%):  Development security automation: Found 2 potentially security-related Lambda function(s).;  EventBridge rule data unavailable.",
@@ -4440,10 +4808,11 @@
       "requirement": "Require role-specific training for development and engineering staff covering best practices for delivering secure software",
       "remediated_at": "2025-11-04T20:35:49.801362Z",
       "remediation_commit": "95ffb952c4bdb3c43725922acae9f622b4b95099",
-      "duration_hours": 1.81
+      "duration_hours": 1.81,
+      "legacy_ksi_id": "KSI-CED-03"
     },
     {
-      "ksi_id": "KSI-CNA-01",
+      "ksi_id": "KSI-CNA-RNT",
       "failed_at": "2025-11-04T20:35:49.801362Z",
       "failed_commit": "95ffb952c4bdb3c43725922acae9f622b4b95099",
       "reason": "Below threshold: 5/16 (31.2%) - requires 50.0% for LOW impact:  VPC infrastructure: 1 VPC(s) detected;  Strong ingress controls: 15/15 security groups restrictive;  Strong egress controls: 14/15 security groups control outbound traffic;  Default security group properly secured;  Custom network controls: 1/1 Network ACLs with custom traffic filtering rules;  Controlled egress routing: 1 private route tables with NAT gateway routing;  Managed egress: 1 NAT gateways for controlled outbound access; ",
@@ -4452,10 +4821,11 @@
       "requirement": "Configure ALL machine-based information resources to limit inbound and outbound traffic",
       "remediated_at": "2025-11-19T06:23:38.098154Z",
       "remediation_commit": "20a0c6641c9c04fcf67f0a270b2092109f9f763a",
-      "duration_hours": 345.8
+      "duration_hours": 345.8,
+      "legacy_ksi_id": "KSI-CNA-01"
     },
     {
-      "ksi_id": "KSI-PIY-03",
+      "ksi_id": "KSI-PIY-RVD",
       "failed_at": "2025-11-04T20:35:49.801362Z",
       "failed_commit": "95ffb952c4bdb3c43725922acae9f622b4b95099",
       "reason": "No vulnerability disclosure program detected (1/14):  VDP maintenance activity: 1 updates",
@@ -4464,10 +4834,11 @@
       "requirement": "Maintain a vulnerability disclosure program",
       "remediated_at": "2025-11-19T06:23:38.098154Z",
       "remediation_commit": "20a0c6641c9c04fcf67f0a270b2092109f9f763a",
-      "duration_hours": 345.8
+      "duration_hours": 345.8,
+      "legacy_ksi_id": "KSI-PIY-03"
     },
     {
-      "ksi_id": "KSI-AFR-08",
+      "ksi_id": "FRR-AFC",
       "failed_at": "2025-11-21T02:46:58.182803Z",
       "failed_commit": "e5a58efe8b9b24143e01289e11eb5cd545670e26",
       "reason": "Insufficient 0/5 (0%):  [Documentation] Security Inbox Procedures NOT found in the expected CodeCommit path.",
@@ -4476,10 +4847,11 @@
       "requirement": "Operate a secure inbox to receive critical communication from FedRAMP and other government entities in alignment with FedRAMP Security Inbox (FSI) requirements and persistently address all related requirements and recommendations.",
       "remediated_at": "2025-11-21T06:24:47.645788Z",
       "remediation_commit": "778915f431219282cb146f7abba1c501bf52a55d",
-      "duration_hours": 3.63
+      "duration_hours": 3.63,
+      "legacy_ksi_id": "KSI-AFR-08"
     },
     {
-      "ksi_id": "KSI-AFR-07",
+      "ksi_id": "FRR-SCG",
       "failed_at": "2025-11-21T02:46:58.182803Z",
       "failed_commit": "e5a58efe8b9b24143e01289e11eb5cd545670e26",
       "reason": "Insufficient 0/5 (0%):  [Documentation] Secure Configuration Guide NOT found in the expected CodeCommit path.",
@@ -4488,10 +4860,11 @@
       "requirement": "Develop secure by default configurations and provide guidance for secure configuration of the cloud service offering to customers in alignment with the FedRAMP Recommended Secure Configuration (RSC) guidance standard and persistently address all related requirements and recommendations.",
       "remediated_at": "2025-11-22T07:41:21.596666Z",
       "remediation_commit": "656dc40cb2d68b2075d6bcae7f97896f31f763b9",
-      "duration_hours": 28.91
+      "duration_hours": 28.91,
+      "legacy_ksi_id": "KSI-AFR-07"
     },
     {
-      "ksi_id": "KSI-IAM-04",
+      "ksi_id": "KSI-IAM-JIT",
       "failed_at": "2025-11-22T00:20:45.857150Z",
       "failed_commit": "02d8b96b8fd6250aa955c2b94087e220f36bb51c",
       "reason": "Below threshold: 6/10 (60.0%) - requires 64.0% for MODERATE impact:  [Modern Auth] IAM Identity Center active: 1 instance(s) found.;  [Least Privilege] Excellent: 97 roles and 0 IAM users (Pure Role-Based Access).;  [Just-in-Time] Caller identity unavailable.",
@@ -4500,10 +4873,11 @@
       "requirement": "Use a least-privileged, role and attribute-based, and just-in-time security authorization model for all user and non-user accounts and services.",
       "remediated_at": "2025-11-22T07:41:21.596666Z",
       "remediation_commit": "656dc40cb2d68b2075d6bcae7f97896f31f763b9",
-      "duration_hours": 7.34
+      "duration_hours": 7.34,
+      "legacy_ksi_id": "KSI-IAM-04"
     },
     {
-      "ksi_id": "KSI-IAM-05",
+      "ksi_id": "KSI-IAM-ELP",
       "failed_at": "2025-11-22T00:20:45.857150Z",
       "failed_commit": "02d8b96b8fd6250aa955c2b94087e220f36bb51c",
       "reason": "Critical Zero Trust Gaps Detected (100%):  [Monitoring] CRITICAL GAP: CloudTrail ('meridianks-Management-events') is configured but IS NOT LOGGING.;  [Identity] Modern Zero Trust identity platform is in use (IAM Identity Center).;  [Segmentation] Security group data unavailable.",
@@ -4512,10 +4886,11 @@
       "requirement": "Configure identity and access management with measures that always verify each user or device can only access the resources they need.",
       "remediated_at": "2025-11-22T07:41:21.596666Z",
       "remediation_commit": "656dc40cb2d68b2075d6bcae7f97896f31f763b9",
-      "duration_hours": 7.34
+      "duration_hours": 7.34,
+      "legacy_ksi_id": "KSI-IAM-05"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-11-22T00:20:45.857150Z",
       "failed_commit": "02d8b96b8fd6250aa955c2b94087e220f36bb51c",
       "reason": "Insufficient 5/10 (50%):  [Retention] All 2 backup plans meet retention requirements (>28 days).;  [Execution] Backup job history unavailable.",
@@ -4524,10 +4899,11 @@
       "requirement": "Perform system backups aligned with recovery objectives.",
       "remediated_at": "2025-11-22T07:41:21.596666Z",
       "remediation_commit": "656dc40cb2d68b2075d6bcae7f97896f31f763b9",
-      "duration_hours": 7.34
+      "duration_hours": 7.34,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-SVC-10",
+      "ksi_id": "KSI-SVC-RUD",
       "failed_at": "2025-11-22T00:20:45.857150Z",
       "failed_commit": "02d8b96b8fd6250aa955c2b94087e220f36bb51c",
       "reason": "Below threshold: 6/10 (60.0%) - requires 64.0% for MODERATE impact:  [Backup Retention] AWS Backup plan data unavailable.;  [S3 Lifecycle] 4 S3 bucket(s) have active lifecycle policies with object expiration/cleanup.;  [Log Retention] Strong log retention strategy: 31/33 (94%) log groups have a defined retention period.",
@@ -4536,10 +4912,11 @@
       "requirement": "Remove unwanted federal customer data promptly when requested by an agency in alignment with customer agreements, including from backups if appropriate.",
       "remediated_at": "2025-11-22T07:41:21.596666Z",
       "remediation_commit": "656dc40cb2d68b2075d6bcae7f97896f31f763b9",
-      "duration_hours": 7.34
+      "duration_hours": 7.34,
+      "legacy_ksi_id": "KSI-SVC-10"
     },
     {
-      "ksi_id": "KSI-AFR-04",
+      "ksi_id": "FRR-VDR",
       "failed_at": "2025-11-21T02:46:58.182803Z",
       "failed_commit": "e5a58efe8b9b24143e01289e11eb5cd545670e26",
       "reason": "Insufficient 5/10 (50%):  [Technical] Inspector check failed:  Insufficient 4/18 (22%):  Security Hub standards data unavailable.;  Automated vulnerability scanning: Inspector enabled for EC2, ECR.;  Multi-service vulnerability coverage via Inspector (2 services).;  [Documentation] Vulnerability Policy/Tracker found in CodeCommit.;  [Quality] Document appears substantial (195834 bytes).",
@@ -4548,10 +4925,11 @@
       "requirement": "Document the vulnerability detection and vulnerability response methodology used within the cloud service offering in alignment with the FedRAMP Vulnerability Detection and Response (VDR) standard and persistently address all related requirements and recommendations.",
       "remediated_at": "2025-11-23T03:47:03.380509Z",
       "remediation_commit": "93fc7b7f0a7602cbeab0473e15f050d7cf7a8760",
-      "duration_hours": 49.0
+      "duration_hours": 49.0,
+      "legacy_ksi_id": "KSI-AFR-04"
     },
     {
-      "ksi_id": "KSI-AFR-08",
+      "ksi_id": "FRR-AFC",
       "failed_at": "2025-11-22T00:20:45.857150Z",
       "failed_commit": "02d8b96b8fd6250aa955c2b94087e220f36bb51c",
       "reason": "Insufficient 0/10 (0%):  [MX Records] No MX records found for meridianks.com - cannot receive email;  [SPF] No SPF record found for meridianks.com (recommended for email authentication);  [DMARC] No DMARC record found for _dmarc.meridianks.com (recommended for email security);  [Procedures] Security inbox procedures document not found in security-governance repo",
@@ -4560,10 +4938,11 @@
       "requirement": "Operate a secure inbox to receive critical communication from FedRAMP and other government entities in alignment with FedRAMP Security Inbox (FSI) requirements and persistently address all related requirements and recommendations.",
       "remediated_at": "2025-11-23T03:47:03.380509Z",
       "remediation_commit": "93fc7b7f0a7602cbeab0473e15f050d7cf7a8760",
-      "duration_hours": 27.44
+      "duration_hours": 27.44,
+      "legacy_ksi_id": "KSI-AFR-08"
     },
     {
-      "ksi_id": "KSI-AFR-10",
+      "ksi_id": "FRR-IEC",
       "failed_at": "2025-11-22T00:20:45.857150Z",
       "failed_commit": "02d8b96b8fd6250aa955c2b94087e220f36bb51c",
       "reason": "Insufficient 0/10 (0%):  [ICP Playbook] ICP playbook not found in security-governance repo;  [Incident Response Plan] Incident response plan not found in security-governance repo;  [Automation] incident_logging.yaml workflow not found in repository;  [SNS Topics] Could not verify SNS topic configuration;  [SNS Subscriptions] Could not verify SNS subscriptions",
@@ -4572,10 +4951,11 @@
       "requirement": "Integrate FedRAMP's Incident Communications Procedures (ICP) into incident response procedures and persistently address all related requirements and recommendations.",
       "remediated_at": "2025-11-23T03:47:03.380509Z",
       "remediation_commit": "93fc7b7f0a7602cbeab0473e15f050d7cf7a8760",
-      "duration_hours": 27.44
+      "duration_hours": 27.44,
+      "legacy_ksi_id": "KSI-AFR-10"
     },
     {
-      "ksi_id": "KSI-AFR-11",
+      "ksi_id": "FRR-CMU",
       "failed_at": "2025-11-21T02:46:58.182803Z",
       "failed_commit": "e5a58efe8b9b24143e01289e11eb5cd545670e26",
       "reason": "Insufficient 5/10 (50%):  [Technical] Encryption check failed:  Insufficient 0/20 (0%): No detailed findings;  [Documentation] UCM Policy found in CodeCommit.;  [Quality] Document appears substantial (10428 bytes).",
@@ -4584,10 +4964,11 @@
       "requirement": "Ensure that cryptographic modules used to protect potentially sensitive federal customer data are selected and used in alignment with the FedRAMP 20x Using Cryptographic Modules (UCM) policy and persistently address all related requirements and recommendations.",
       "remediated_at": "2025-11-23T03:47:03.380509Z",
       "remediation_commit": "93fc7b7f0a7602cbeab0473e15f050d7cf7a8760",
-      "duration_hours": 49.0
+      "duration_hours": 49.0,
+      "legacy_ksi_id": "KSI-AFR-11"
     },
     {
-      "ksi_id": "KSI-CNA-05",
+      "ksi_id": "KSI-CNA-RVP",
       "failed_at": "2025-11-22T00:20:45.857150Z",
       "failed_commit": "02d8b96b8fd6250aa955c2b94087e220f36bb51c",
       "reason": "Error in wrapped function evaluate_KSI_CNA_05: 'list' object has no attribute 'get'",
@@ -4596,10 +4977,11 @@
       "requirement": "Protect against denial of service attacks and other unwanted activity.",
       "remediated_at": "2025-11-23T03:47:03.380509Z",
       "remediation_commit": "93fc7b7f0a7602cbeab0473e15f050d7cf7a8760",
-      "duration_hours": 27.44
+      "duration_hours": 27.44,
+      "legacy_ksi_id": "KSI-CNA-05"
     },
     {
-      "ksi_id": "KSI-SVC-08",
+      "ksi_id": "KSI-SVC-PRR",
       "failed_at": "2025-11-22T00:20:45.857150Z",
       "failed_commit": "02d8b96b8fd6250aa955c2b94087e220f36bb51c",
       "reason": "Below threshold: 6/10 (60.0%) - requires 64.0% for MODERATE impact:  [IaC] S3 bucket data (s3://mks-states/) unavailable or bucket not found.;  [IaC Controls] IaC Scan Artifact ('checkov_scan_summary.json') found in CMT-03 evidence.;  [IaC Controls] Testing Proof Artifact ('automated_testing_proof.json') found in CMT-03 evidence.",
@@ -4608,10 +4990,11 @@
       "requirement": "Do not introduce or leave behind residual elements that could negatively affect confidentiality, integrity, or availability of federal customer data during operations.",
       "remediated_at": "2025-11-23T03:47:03.380509Z",
       "remediation_commit": "93fc7b7f0a7602cbeab0473e15f050d7cf7a8760",
-      "duration_hours": 27.44
+      "duration_hours": 27.44,
+      "legacy_ksi_id": "KSI-SVC-08"
     },
     {
-      "ksi_id": "KSI-CNA-07",
+      "ksi_id": "KSI-CNA-IBP",
       "failed_at": "2025-11-22T00:20:45.857150Z",
       "failed_commit": "02d8b96b8fd6250aa955c2b94087e220f36bb51c",
       "reason": "Error in wrapped function evaluate_KSI_CNA_07: name 'snapshots' is not defined",
@@ -4620,10 +5003,11 @@
       "requirement": "Ensure cloud-native information resources are implemented based on host provider's best practices and documented guidance.",
       "remediated_at": "2025-11-23T08:20:21.394861Z",
       "remediation_commit": "b79cfa04b3924f7b166b23bbd22d16744913920d",
-      "duration_hours": 31.99
+      "duration_hours": 31.99,
+      "legacy_ksi_id": "KSI-CNA-07"
     },
     {
-      "ksi_id": "KSI-AFR-05",
+      "ksi_id": "FRR-SCN",
       "failed_at": "2025-11-21T02:46:58.182803Z",
       "failed_commit": "e5a58efe8b9b24143e01289e11eb5cd545670e26",
       "reason": "Insufficient 5/10 (50%):  [Technical] Terraform plan check failed: Error in wrapped function evaluate_KSI_CMT_05: 'str' object has no attribute 'get';  [Documentation] Change Management Tracker found in CodeCommit.;  [Quality] Document appears substantial (195834 bytes).",
@@ -4632,10 +5016,11 @@
       "requirement": "Determine how significant changes will be tracked and how all necessary parties will be notified in alignment with the FedRAMP Significant Change Notifications (SCN) standard and persistently address all related requirements and recommendations.",
       "remediated_at": "2025-12-03T12:29:53.029833Z",
       "remediation_commit": "903cb444d4217a053ac65ad3bc9ad56c724be170",
-      "duration_hours": 297.72
+      "duration_hours": 297.72,
+      "legacy_ksi_id": "KSI-AFR-05"
     },
     {
-      "ksi_id": "KSI-AFR-09",
+      "ksi_id": "FRR-SDR",
       "failed_at": "2025-11-21T02:46:58.182803Z",
       "failed_commit": "e5a58efe8b9b24143e01289e11eb5cd545670e26",
       "reason": "Insufficient 0/10 (0%):  [Documentation] Validation Architecture Diagram NOT found in the expected CodeCommit path.;  [Technical] EventBridge validation schedule not explicitly found.",
@@ -4644,10 +5029,11 @@
       "requirement": "Persistently validate, assess, and report on the effectiveness and status of security decisions and policies that are implemented within the cloud service offering in alignment with the FedRAMP 20x Persistent Validation and Assessment (PVA) standard, and persistently address all related requirements and recommendations.",
       "remediated_at": "2025-12-03T12:29:53.029833Z",
       "remediation_commit": "903cb444d4217a053ac65ad3bc9ad56c724be170",
-      "duration_hours": 297.72
+      "duration_hours": 297.72,
+      "legacy_ksi_id": "KSI-AFR-09"
     },
     {
-      "ksi_id": "KSI-CMT-04",
+      "ksi_id": "KSI-CMT-RVP",
       "failed_at": "2025-11-22T00:20:45.857150Z",
       "failed_commit": "02d8b96b8fd6250aa955c2b94087e220f36bb51c",
       "reason": "Insufficient 5/10 (50%):  [Documentation] Comprehensive change management procedure found (size: 3747 bytes).;  [Evidence] Could not access S3 evidence bucket to verify Terraform plan artifacts.",
@@ -4656,10 +5042,11 @@
       "requirement": "Always follow a documented change management procedure.",
       "remediated_at": "2025-12-03T16:28:09.326638Z",
       "remediation_commit": "a7214fabae14d1cefc3fb767c001426d9e112598",
-      "duration_hours": 280.12
+      "duration_hours": 280.12,
+      "legacy_ksi_id": "KSI-CMT-04"
     },
     {
-      "ksi_id": "KSI-AFR-01",
+      "ksi_id": "FRR-MAS",
       "failed_at": "2025-12-11T08:33:51.566707Z",
       "failed_commit": "be8471929d93d9dce090a2c5e9be55a679b66562",
       "reason": "Error in wrapped function evaluate_KSI_AFR_01: evaluate_KSI_AFR_01() missing 1 required positional argument: 'peripheral_output'",
@@ -4668,10 +5055,11 @@
       "requirement": "Apply the FedRAMP Minimum Assessment Standard (MAS) to identify and document the scope of the cloud service offering to be assessed for FedRAMP authorization and persistently address all related requirements and recommendations.",
       "remediated_at": "2025-12-22T03:23:53.810599Z",
       "remediation_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
-      "duration_hours": 258.83
+      "duration_hours": 258.83,
+      "legacy_ksi_id": "KSI-AFR-01"
     },
     {
-      "ksi_id": "KSI-CED-03",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-11-19T06:23:38.098154Z",
       "failed_commit": "20a0c6641c9c04fcf67f0a270b2092109f9f763a",
       "reason": "Insufficient 2/7 (29%):  Development security automation: Found 2 potentially security-related Lambda function(s).;  EventBridge rule data unavailable.",
@@ -4680,10 +5068,11 @@
       "requirement": "Require role-specific training for development and engineering staff covering best practices for delivering secure software",
       "remediated_at": "2025-12-22T03:23:53.810599Z",
       "remediation_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
-      "duration_hours": 789.0
+      "duration_hours": 789.0,
+      "legacy_ksi_id": "KSI-CED-03"
     },
     {
-      "ksi_id": "KSI-CED-04",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2025-11-21T02:46:58.182803Z",
       "failed_commit": "e5a58efe8b9b24143e01289e11eb5cd545670e26",
       "reason": "Below threshold: 3/5 (60.0%) - requires 64.0% for MODERATE impact:  Files found but filenames lack keywords (expected 'incident', 'dr', etc.): cli_output.json",
@@ -4692,10 +5081,11 @@
       "requirement": "Require and monitor the effectiveness of role-specific training to staff involved with incident response or disaster recovery.",
       "remediated_at": "2025-12-22T03:23:53.810599Z",
       "remediation_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
-      "duration_hours": 744.62
+      "duration_hours": 744.62,
+      "legacy_ksi_id": "KSI-CED-04"
     },
     {
-      "ksi_id": "KSI-PIY-08",
+      "ksi_id": "KSI-PIY-RES",
       "failed_at": "2025-11-21T02:46:58.182803Z",
       "failed_commit": "e5a58efe8b9b24143e01289e11eb5cd545670e26",
       "reason": "Below threshold: 3/5 (60.0%) - requires 64.0% for MODERATE impact:  Files found but filenames lack keywords (expected 'briefing', 'budget', etc.): cli_output.json",
@@ -4704,10 +5094,11 @@
       "requirement": "Regularly measure executive support for achieving the organization\u2019s security objectives.",
       "remediated_at": "2025-12-22T03:23:53.810599Z",
       "remediation_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
-      "duration_hours": 744.62
+      "duration_hours": 744.62,
+      "legacy_ksi_id": "KSI-PIY-08"
     },
     {
-      "ksi_id": "KSI-INR-01",
+      "ksi_id": "KSI-INR-RIR",
       "failed_at": "2025-12-22T03:23:53.810599Z",
       "failed_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
       "reason": "Technical Failure (0%): CLI Execution Error: Exit code 254: \nAn error occurred (AccessDeniedException) when calling the ListRepositories operation: User: arn:aws:sts::893894210484:assumed-role/githubactions_role/Github_to_AWS_Federated is not authorized to per",
@@ -4716,10 +5107,11 @@
       "requirement": "Always follow a documented incident response procedure.",
       "remediated_at": "2025-12-23T16:22:34.822776Z",
       "remediation_commit": "b8ec13458fd7ea3cf41d19c02a577d2864967f22",
-      "duration_hours": 36.98
+      "duration_hours": 36.98,
+      "legacy_ksi_id": "KSI-INR-01"
     },
     {
-      "ksi_id": "KSI-INR-03",
+      "ksi_id": "KSI-INR-AAR",
       "failed_at": "2025-12-22T03:23:53.810599Z",
       "failed_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
       "reason": "Technical Failure (0%): CLI Execution Error: Exit code 254: \nAn error occurred (AccessDeniedException) when calling the ListRepositories operation: User: arn:aws:sts::893894210484:assumed-role/githubactions_role/Github_to_AWS_Federated is not authorized to per",
@@ -4728,10 +5120,11 @@
       "requirement": "Generate after action reports and regularly incorporate lessons learned into operations.",
       "remediated_at": "2025-12-23T16:22:34.822776Z",
       "remediation_commit": "b8ec13458fd7ea3cf41d19c02a577d2864967f22",
-      "duration_hours": 36.98
+      "duration_hours": 36.98,
+      "legacy_ksi_id": "KSI-INR-03"
     },
     {
-      "ksi_id": "KSI-SVC-04",
+      "ksi_id": "KSI-SVC-ACM",
       "failed_at": "2025-12-22T03:23:53.810599Z",
       "failed_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
       "reason": "Technical Failure (0%): CLI Execution Error: Exit code 254: \nAn error occurred (FileDoesNotExistException) when calling the GetFile operation: Could not find path policies/configuration-management-policy.md",
@@ -4740,10 +5133,11 @@
       "requirement": "Manage configuration of machine-based information resources using automation.",
       "remediated_at": "2025-12-28T00:46:33.818471Z",
       "remediation_commit": "f920a34d3ba1e28bac540042c81d6c091088ee28",
-      "duration_hours": 141.38
+      "duration_hours": 141.38,
+      "legacy_ksi_id": "KSI-SVC-04"
     },
     {
-      "ksi_id": "KSI-CNA-07",
+      "ksi_id": "KSI-CNA-IBP",
       "failed_at": "2025-12-22T03:23:53.810599Z",
       "failed_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
       "reason": "Insufficient (47%): 34 items: 16 verified, 18 failed",
@@ -4752,7 +5146,8 @@
       "requirement": "Maximize use of managed services and cloud resources",
       "remediated_at": "2025-12-28T08:20:43.700384Z",
       "remediation_commit": "a6483245a2ea48585dcb8ad5bbb7eb8236da71c5",
-      "duration_hours": 148.95
+      "duration_hours": 148.95,
+      "legacy_ksi_id": "KSI-CNA-07"
     },
     {
       "ksi_id": "KSI-PIY-02",
@@ -4764,10 +5159,12 @@
       "requirement": "Document the security objectives and requirements for each information resource.",
       "remediated_at": "2025-12-28T08:20:43.700384Z",
       "remediation_commit": "a6483245a2ea48585dcb8ad5bbb7eb8236da71c5",
-      "duration_hours": 148.95
+      "duration_hours": 148.95,
+      "legacy_ksi_id": "KSI-PIY-02",
+      "retired_pre_cr26": true
     },
     {
-      "ksi_id": "KSI-AFR-01",
+      "ksi_id": "FRR-MAS",
       "failed_at": "2025-12-28T11:18:28.362338Z",
       "failed_commit": "22ab0ee41a13c2955af43ee6c945368299c6e67e",
       "reason": "Insufficient (57%): 19 items: 11 verified, 8 failed",
@@ -4776,10 +5173,11 @@
       "requirement": "Validates the complete FedRAMP Minimum Assessment Scope (MAS). This rule enforces Structural Boundaries (VPC ID) for compute assets AND validates that all peripheral assets (S3, RDS, ALB) are accounted for in the inventory.",
       "remediated_at": "2025-12-28T12:27:22.262581Z",
       "remediation_commit": "a2c85095e00f9907fdda4f7cf47a6037d4ae61b2",
-      "duration_hours": 1.15
+      "duration_hours": 1.15,
+      "legacy_ksi_id": "KSI-AFR-01"
     },
     {
-      "ksi_id": "KSI-CMT-02",
+      "ksi_id": "KSI-CMT-RMV",
       "failed_at": "2025-12-28T11:18:28.362338Z",
       "failed_commit": "22ab0ee41a13c2955af43ee6c945368299c6e67e",
       "reason": "Insufficient (10%): 10 items: 1 verified, 9 failed",
@@ -4788,10 +5186,11 @@
       "requirement": "Execute changes though redeployment of version controlled immutable resources rather than direct modification wherever possible",
       "remediated_at": "2025-12-28T12:27:22.262581Z",
       "remediation_commit": "a2c85095e00f9907fdda4f7cf47a6037d4ae61b2",
-      "duration_hours": 1.15
+      "duration_hours": 1.15,
+      "legacy_ksi_id": "KSI-CMT-02"
     },
     {
-      "ksi_id": "KSI-CMT-01",
+      "ksi_id": "KSI-CMT-LMC",
       "failed_at": "2025-12-22T03:23:53.810599Z",
       "failed_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
       "reason": "Insufficient (75%): 4 items: 3 verified, 1 failed",
@@ -4800,10 +5199,11 @@
       "requirement": "Log and monitor modifications to the cloud service offering.",
       "remediated_at": "2025-12-29T04:18:12.025592Z",
       "remediation_commit": "0d050918fdb02a210f069913e4dd2db8e2e60b7c",
-      "duration_hours": 168.91
+      "duration_hours": 168.91,
+      "legacy_ksi_id": "KSI-CMT-01"
     },
     {
-      "ksi_id": "KSI-CNA-01",
+      "ksi_id": "KSI-CNA-RNT",
       "failed_at": "2025-12-28T08:20:43.700384Z",
       "failed_commit": "a6483245a2ea48585dcb8ad5bbb7eb8236da71c5",
       "reason": "Insufficient (14%): 7 items: 1 verified, 6 failed",
@@ -4812,10 +5212,11 @@
       "requirement": "Configure all machine-based information resources to limit inbound and outbound network traffic.",
       "remediated_at": "2025-12-29T19:59:14.822886Z",
       "remediation_commit": "9ac3c2f5e6c18d58f487e027b95c4c580bf0667e",
-      "duration_hours": 35.64
+      "duration_hours": 35.64,
+      "legacy_ksi_id": "KSI-CNA-01"
     },
     {
-      "ksi_id": "KSI-CNA-06",
+      "ksi_id": "KSI-CNA-OFA",
       "failed_at": "2025-12-22T03:23:53.810599Z",
       "failed_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
       "reason": "Insufficient (0%): 4 items: 4 failed",
@@ -4824,10 +5225,11 @@
       "requirement": "Design systems for high availability and rapid recovery.",
       "remediated_at": "2025-12-29T19:59:14.822886Z",
       "remediation_commit": "9ac3c2f5e6c18d58f487e027b95c4c580bf0667e",
-      "duration_hours": 184.59
+      "duration_hours": 184.59,
+      "legacy_ksi_id": "KSI-CNA-06"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2025-12-22T03:23:53.810599Z",
       "failed_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
       "reason": "Insufficient (33%): 3 items: 1 verified, 2 failed",
@@ -4836,10 +5238,11 @@
       "requirement": "Define Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO).",
       "remediated_at": "2025-12-29T19:59:14.822886Z",
       "remediation_commit": "9ac3c2f5e6c18d58f487e027b95c4c580bf0667e",
-      "duration_hours": 184.59
+      "duration_hours": 184.59,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-RPL-02",
+      "ksi_id": "KSI-RPL-ARP",
       "failed_at": "2025-12-22T03:23:53.810599Z",
       "failed_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
       "reason": "Insufficient (16%): 6 items: 1 verified, 5 failed",
@@ -4848,10 +5251,11 @@
       "requirement": "Develop and maintain a recovery plan that aligns with the defined recovery objectives.",
       "remediated_at": "2025-12-29T19:59:14.822886Z",
       "remediation_commit": "9ac3c2f5e6c18d58f487e027b95c4c580bf0667e",
-      "duration_hours": 184.59
+      "duration_hours": 184.59,
+      "legacy_ksi_id": "KSI-RPL-02"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2025-12-22T09:46:09.020033Z",
       "failed_commit": "04ebd9c5ed6b6ea86d19a381faf2e5012a3de507",
       "reason": "Insufficient (25%): 4 items: 1 verified, 3 failed",
@@ -4860,10 +5264,11 @@
       "requirement": "Regularly test the recovery planning capability by performing disaster recovery tests at least annually.",
       "remediated_at": "2025-12-29T19:59:14.822886Z",
       "remediation_commit": "9ac3c2f5e6c18d58f487e027b95c4c580bf0667e",
-      "duration_hours": 178.22
+      "duration_hours": 178.22,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2025-12-22T09:46:09.020033Z",
       "failed_commit": "04ebd9c5ed6b6ea86d19a381faf2e5012a3de507",
       "reason": "Insufficient (25%): 4 items: 1 verified, 3 failed",
@@ -4872,10 +5277,11 @@
       "requirement": "Regularly test the capability to recover from incidents and contingencies.",
       "remediated_at": "2025-12-29T19:59:14.822886Z",
       "remediation_commit": "9ac3c2f5e6c18d58f487e027b95c4c580bf0667e",
-      "duration_hours": 178.22
+      "duration_hours": 178.22,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
-      "ksi_id": "KSI-CNA-02",
+      "ksi_id": "KSI-CNA-MAT",
       "failed_at": "2025-12-22T03:23:53.810599Z",
       "failed_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
       "reason": "Insufficient (0%): 6 items: 6 failed",
@@ -4884,10 +5290,11 @@
       "requirement": "Design systems to minimize the attack surface and minimize lateral movement if compromised.",
       "remediated_at": "2025-12-29T20:51:26.399479Z",
       "remediation_commit": "350fed4dfed11005eebc7fa2f073af942738bc49",
-      "duration_hours": 185.46
+      "duration_hours": 185.46,
+      "legacy_ksi_id": "KSI-CNA-02"
     },
     {
-      "ksi_id": "KSI-CNA-03",
+      "ksi_id": "KSI-CNA-ULN",
       "failed_at": "2025-12-22T03:23:53.810599Z",
       "failed_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
       "reason": "Insufficient (11%): 9 items: 1 verified, 8 failed",
@@ -4896,10 +5303,11 @@
       "requirement": "Use logical networking and related capabilities to enforce traffic flow controls.",
       "remediated_at": "2025-12-29T20:51:26.399479Z",
       "remediation_commit": "350fed4dfed11005eebc7fa2f073af942738bc49",
-      "duration_hours": 185.46
+      "duration_hours": 185.46,
+      "legacy_ksi_id": "KSI-CNA-03"
     },
     {
-      "ksi_id": "KSI-MLA-01",
+      "ksi_id": "KSI-MLA-OSM",
       "failed_at": "2025-12-22T03:23:53.810599Z",
       "failed_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
       "reason": "Insufficient (50%): 2 items: 1 verified, 1 failed",
@@ -4908,10 +5316,11 @@
       "requirement": "Log all activity on all information resources supporting the cloud service offering to a protected audit log.",
       "remediated_at": "2025-12-29T22:04:43.450205Z",
       "remediation_commit": "c437b22820065477f08cf1e4eb0c4a8f503bbd49",
-      "duration_hours": 186.68
+      "duration_hours": 186.68,
+      "legacy_ksi_id": "KSI-MLA-01"
     },
     {
-      "ksi_id": "KSI-AFR-11",
+      "ksi_id": "FRR-CMU",
       "failed_at": "2025-12-29T19:59:14.822886Z",
       "failed_commit": "9ac3c2f5e6c18d58f487e027b95c4c580bf0667e",
       "reason": "Insufficient (77%): 9 items: 7 verified, 2 failed",
@@ -4920,10 +5329,11 @@
       "requirement": "Ensure that cryptographic modules are selected and used in alignment with the FedRAMP 20x Using Cryptographic Modules (UCM) policy.",
       "remediated_at": "2025-12-29T22:51:11.376984Z",
       "remediation_commit": "a9dbc6a2d8a6dd23a8ae29a69430967e28072a59",
-      "duration_hours": 2.87
+      "duration_hours": 2.87,
+      "legacy_ksi_id": "KSI-AFR-11"
     },
     {
-      "ksi_id": "KSI-AFR-07",
+      "ksi_id": "FRR-SCG",
       "failed_at": "2025-12-22T03:23:53.810599Z",
       "failed_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
       "reason": "Insufficient (0%): No resources found matching validation criteria",
@@ -4932,10 +5342,11 @@
       "requirement": "Document the secure configuration baseline for the cloud service offering.",
       "remediated_at": "2025-12-31T00:27:02.231928Z",
       "remediation_commit": "dcbcbad0df736c01322ab867c6799f4bafe5434f",
-      "duration_hours": 213.05
+      "duration_hours": 213.05,
+      "legacy_ksi_id": "KSI-AFR-07"
     },
     {
-      "ksi_id": "KSI-MLA-08",
+      "ksi_id": "KSI-MLA-ALA",
       "failed_at": "2025-12-22T03:23:53.810599Z",
       "failed_commit": "dcb2b9974e93717dd8b84f2b8bc78f2dcff32f83",
       "reason": "Insufficient (0%): No resources found matching validation criteria",
@@ -4944,10 +5355,11 @@
       "requirement": "Use a least-privileged, role and attribute-based, and just-in-time access authorization model for access to log data.",
       "remediated_at": "2025-12-31T05:46:13.485269Z",
       "remediation_commit": "5daaa86a27e3453ee481d240371bbae5cdcc82a5",
-      "duration_hours": 218.37
+      "duration_hours": 218.37,
+      "legacy_ksi_id": "KSI-MLA-08"
     },
     {
-      "ksi_id": "KSI-AFR-06",
+      "ksi_id": "FRR-CCM",
       "failed_at": "2026-03-09T21:42:24.916581Z",
       "failed_commit": "9e42f6227587a3a8c16cdc9e8282cad596c7da0c",
       "reason": "Insufficient (0%): Maintain a plan and process for providing Ongoing Authorization Reports and Quarterly Reviews. | 0/2 resources compliant. | Warnings: 3PAO audit report 'None' exists, size: 2 KB, freshness: recent (80d), versioned. Outcome concerns: artifact is unusually small (2149 bytes, expected >10240 bytes for audit_report).; Service check for 'unknown': unable to determine specific compliance (manual review).",
@@ -4957,10 +5369,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-03-11T00:26:55.873135Z",
       "remediation_commit": "f9dc8c3b61d9dcff3318c0933dc399edbf03ab38",
-      "duration_hours": 26.74
+      "duration_hours": 26.74,
+      "legacy_ksi_id": "KSI-AFR-06"
     },
     {
-      "ksi_id": "KSI-AFR-02",
+      "ksi_id": "FRR-FRC",
       "failed_at": "2026-03-09T21:42:24.916581Z",
       "failed_commit": "9e42f6227587a3a8c16cdc9e8282cad596c7da0c",
       "reason": "Insufficient (50%): Set security goals and develop automated validation of status and progress. | 1/2 resources compliant. | Verified: Compliance scorecard 'None' exists, size: 95 KB, freshness: current (0d), versioned. | Failures: No Security Hub standards enabled. Automated security posture assessment is missing.",
@@ -4970,10 +5383,11 @@
       "score_at_failure": 50,
       "remediated_at": "2026-03-11T06:50:28.470258Z",
       "remediation_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
-      "duration_hours": 33.13
+      "duration_hours": 33.13,
+      "legacy_ksi_id": "KSI-AFR-02"
     },
     {
-      "ksi_id": "KSI-AFR-07",
+      "ksi_id": "FRR-SCG",
       "failed_at": "2026-03-09T21:42:24.916581Z",
       "failed_commit": "9e42f6227587a3a8c16cdc9e8282cad596c7da0c",
       "reason": "Insufficient (0%): Document the secure configuration baseline for the cloud service offering. | 0/1 resources compliant. | Failures: No Security Hub standards enabled. Automated security posture assessment is missing.",
@@ -4983,10 +5397,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-03-11T06:50:28.470258Z",
       "remediation_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
-      "duration_hours": 33.13
+      "duration_hours": 33.13,
+      "legacy_ksi_id": "KSI-AFR-07"
     },
     {
-      "ksi_id": "KSI-AFR-08",
+      "ksi_id": "FRR-AFC",
       "failed_at": "2026-03-09T21:42:24.916581Z",
       "failed_commit": "9e42f6227587a3a8c16cdc9e8282cad596c7da0c",
       "reason": "Insufficient (25%): Operate a secure inbox to receive critical communication from FedRAMP and other government entities. | 1/4 resources compliant. | Verified: Verified: Governance document 'security-governance' is substantive (3532 bytes, 12 sections). | Warnings: No SNS topics found for security alerting.; No SNS topics found for security alerting. |   ...and 1 more warning(s)",
@@ -4996,10 +5411,11 @@
       "score_at_failure": 25,
       "remediated_at": "2026-03-11T06:50:28.470258Z",
       "remediation_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
-      "duration_hours": 33.13
+      "duration_hours": 33.13,
+      "legacy_ksi_id": "KSI-AFR-08"
     },
     {
-      "ksi_id": "KSI-AFR-10",
+      "ksi_id": "FRR-IEC",
       "failed_at": "2026-03-09T21:42:24.916581Z",
       "failed_commit": "9e42f6227587a3a8c16cdc9e8282cad596c7da0c",
       "reason": "Insufficient (33%): Integrate FedRAMP's Incident Communications Procedures (ICP) into incident response procedures and infrastructure. | 2/6 resources compliant. | Verified: Verified: Governance document 'security-governance' is substantive (10426 bytes, 29 sections).; Verified: Governance document 'security-governance' is substantive (5730 bytes, 9 sections). | Warnings: No SNS topics found for security alerting.; No SNS topics found for security alerting. |   ...and 2 more warning(s)",
@@ -5009,10 +5425,11 @@
       "score_at_failure": 33,
       "remediated_at": "2026-03-11T06:50:28.470258Z",
       "remediation_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
-      "duration_hours": 33.13
+      "duration_hours": 33.13,
+      "legacy_ksi_id": "KSI-AFR-10"
     },
     {
-      "ksi_id": "KSI-AFR-11",
+      "ksi_id": "FRR-CMU",
       "failed_at": "2026-03-11T03:52:46.025658Z",
       "failed_commit": "0f3a915976edbec0f3c3ed7a5c5bbdc7a2dd0d4e",
       "reason": "Insufficient (22%): Ensure that cryptographic modules are selected and used in alignment with the FedRAMP 20x Using Cryptographic Modules... | 2/9 resources compliant. | Verified: Resource 'saas' is Encrypted at Rest.; Verified: Governance document 'security-governance' is substantive (6522 bytes, 25 sections). | Failures: Critical: Resource 'None' is NOT Encrypted at Rest.; Critical: Resource 'None' is NOT Encrypted at Rest.; Critical: Resource 'None' is NOT Encrypted at Rest. |   ...and 4 more failure(s)",
@@ -5022,10 +5439,11 @@
       "score_at_failure": 22,
       "remediated_at": "2026-03-11T06:50:28.470258Z",
       "remediation_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
-      "duration_hours": 2.96
+      "duration_hours": 2.96,
+      "legacy_ksi_id": "KSI-AFR-11"
     },
     {
-      "ksi_id": "KSI-CMT-01",
+      "ksi_id": "KSI-CMT-LMC",
       "failed_at": "2026-03-11T03:52:46.025658Z",
       "failed_commit": "0f3a915976edbec0f3c3ed7a5c5bbdc7a2dd0d4e",
       "reason": "Insufficient (75%): Log and monitor modifications to the cloud service offering. | 3/4 resources compliant. | Verified: Trail is Secure (Multi-Region, Validated, Encrypted); Trail captures management events (1 selectors configured).; Verified: Governance document 'security-governance' is substantive (764 bytes, 5 sections). | Warnings: Service check for 'None': unable to determine specific compliance (manual review).",
@@ -5035,10 +5453,11 @@
       "score_at_failure": 75,
       "remediated_at": "2026-03-11T06:50:28.470258Z",
       "remediation_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
-      "duration_hours": 2.96
+      "duration_hours": 2.96,
+      "legacy_ksi_id": "KSI-CMT-01"
     },
     {
-      "ksi_id": "KSI-CMT-03",
+      "ksi_id": "KSI-CMT-VTD",
       "failed_at": "2026-03-11T03:52:46.025658Z",
       "failed_commit": "0f3a915976edbec0f3c3ed7a5c5bbdc7a2dd0d4e",
       "reason": "Insufficient (50%): Automate persistent testing and validation of changes throughout deployment. | 1/2 resources compliant. | Verified: Verified: Governance document 'security-governance' is substantive (5023 bytes, 21 sections). | Warnings: Service check for 'None': unable to determine specific compliance (manual review).",
@@ -5048,10 +5467,11 @@
       "score_at_failure": 50,
       "remediated_at": "2026-03-11T06:50:28.470258Z",
       "remediation_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
-      "duration_hours": 2.96
+      "duration_hours": 2.96,
+      "legacy_ksi_id": "KSI-CMT-03"
     },
     {
-      "ksi_id": "KSI-CNA-04",
+      "ksi_id": "KSI-CNA-DFP",
       "failed_at": "2026-03-11T03:52:46.025658Z",
       "failed_commit": "0f3a915976edbec0f3c3ed7a5c5bbdc7a2dd0d4e",
       "reason": "Insufficient (2%): Use immutable infrastructure with strictly defined functionality and privileges by default. | 2/77 resources compliant. | Verified: Change notification artifact 'None' exists.; Compliant: SG 'mksfr-outbound-inet-sg1' properly limits network traffic with appropriate restrictions. | Warnings: IAM resource type 'unknown' has no specific evaluation rule (manual review required).; IAM resource type 'unknown' has no specific evaluation rule (manual review required). |   ...and 73 more warning(s)",
@@ -5061,10 +5481,11 @@
       "score_at_failure": 2,
       "remediated_at": "2026-03-11T06:50:28.470258Z",
       "remediation_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
-      "duration_hours": 2.96
+      "duration_hours": 2.96,
+      "legacy_ksi_id": "KSI-CNA-04"
     },
     {
-      "ksi_id": "KSI-CNA-05",
+      "ksi_id": "KSI-CNA-RVP",
       "failed_at": "2026-03-11T03:52:46.025658Z",
       "failed_commit": "0f3a915976edbec0f3c3ed7a5c5bbdc7a2dd0d4e",
       "reason": "Insufficient (66%): Persistently review the effectiveness of protection against denial of service attacks and other unwanted activity. | 4/6 resources compliant. | Verified: AWS Shield Standard active on load balancer 'unknown-lb' (Layer 3/4 DDoS protection).;  Manual Review Required: Unidentified resource. Document 'generic_document' accessible. | Failures: No WAF Web ACLs found. Layer 7 DDoS protection is missing. | Warnings: No Route53 hosted zones found. DNS may not be protected by AWS AnyCast.",
@@ -5074,10 +5495,11 @@
       "score_at_failure": 66,
       "remediated_at": "2026-03-11T06:50:28.470258Z",
       "remediation_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
-      "duration_hours": 2.96
+      "duration_hours": 2.96,
+      "legacy_ksi_id": "KSI-CNA-05"
     },
     {
-      "ksi_id": "KSI-IAM-03",
+      "ksi_id": "KSI-IAM-SNU",
       "failed_at": "2026-03-11T03:52:46.025658Z",
       "failed_commit": "0f3a915976edbec0f3c3ed7a5c5bbdc7a2dd0d4e",
       "reason": "Insufficient (0%): Enforce appropriately secure authentication methods for non-user accounts and services. | 0/76 resources compliant. | Warnings: IAM resource type 'unknown' has no specific evaluation rule (manual review required).; IAM resource type 'unknown' has no specific evaluation rule (manual review required). |   ...and 74 more warning(s)",
@@ -5087,10 +5509,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-03-11T06:50:28.470258Z",
       "remediation_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
-      "duration_hours": 2.96
+      "duration_hours": 2.96,
+      "legacy_ksi_id": "KSI-IAM-03"
     },
     {
-      "ksi_id": "KSI-AFR-01",
+      "ksi_id": "FRR-MAS",
       "failed_at": "2026-03-09T21:42:24.916581Z",
       "failed_commit": "9e42f6227587a3a8c16cdc9e8282cad596c7da0c",
       "reason": "Insufficient (46%): Validates the complete FedRAMP Minimum Assessment Scope (MAS) covering machine resources, human resources, and proces... | 15/32 resources compliant. | Verified: IMDSv2 Enforced: Instance 'MKSFR-CA' requires HttpTokens.; IMDSv2 Enforced: Instance 'SAAS-KI22LBA' requires HttpTokens.; IMDSv2 Enforced: Instance 'SAAS-RS22' requires HttpTokens. |   ...and 2 more verification(s) | Failures: Risk: Instance 'mksfr-prod-vpc1' allows IMDSv1 (Legacy Metadata). Enforce v2.; Risk: Instance 'MKSFR-UTIL1' allows IMDSv1 (Legacy Metadata). Enforce v2.; Critical: Resource 'unknown-db' is NOT Encrypted at Rest. |   ...and 1 more failure(s) | Warnings: Service check for 'unknown-lb': unable to determine specific compliance (manual review).; IAM resource type 'unknown' has no specific evaluation rule (manual review required). |   ...and 11 more warning(s)",
@@ -5100,10 +5523,11 @@
       "score_at_failure": 46,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 34.69
+      "duration_hours": 34.69,
+      "legacy_ksi_id": "KSI-AFR-01"
     },
     {
-      "ksi_id": "KSI-AFR-03",
+      "ksi_id": "FRR-CDS",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (50%): Determine how authorization data will be shared in alignment with the ADS standard. | 1/2 resources compliant. | Verified: Compliance artifact 'None' exists, size: 1.8 MB, freshness: current (0d), versioned. | Failures: Baseline truncated or missing controls.",
@@ -5113,10 +5537,11 @@
       "score_at_failure": 50,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 1.56
+      "duration_hours": 1.56,
+      "legacy_ksi_id": "KSI-AFR-03"
     },
     {
-      "ksi_id": "KSI-AFR-06",
+      "ksi_id": "FRR-CCM",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (50%): Maintain a plan and process for providing Ongoing Authorization Reports and Quarterly Reviews. | 1/2 resources compliant. | Verified: 3PAO audit report 'None' exists, size: 2 KB, freshness: recent (81d), versioned. | Failures: Baseline truncated or missing controls.",
@@ -5126,10 +5551,11 @@
       "score_at_failure": 50,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 1.56
+      "duration_hours": 1.56,
+      "legacy_ksi_id": "KSI-AFR-06"
     },
     {
-      "ksi_id": "KSI-CNA-07",
+      "ksi_id": "KSI-CNA-IBP",
       "failed_at": "2026-03-11T03:52:46.025658Z",
       "failed_commit": "0f3a915976edbec0f3c3ed7a5c5bbdc7a2dd0d4e",
       "reason": "Insufficient (14%): Persistently ensure cloud-native machine-based information resources are implemented based on the host providers best... | 5/34 resources compliant. | Verified: IMDSv2 Enforced: Instance 'MKSFR-CA' requires HttpTokens.; IMDSv2 Enforced: Instance 'SAAS-KI22LBA' requires HttpTokens.; IMDSv2 Enforced: Instance 'SAAS-RS22' requires HttpTokens. |   ...and 2 more verification(s) | Failures: Risk: Instance 'MKSFR-UTIL1' allows IMDSv1 (Legacy Metadata). Enforce v2. | Warnings: Network resource 'None' (type: None) has no specific evaluation rule (manual review required).; Network resource 'None' (type: None) has no specific evaluation rule (manual review required). |   ...and 26 more warning(s)",
@@ -5139,10 +5565,11 @@
       "score_at_failure": 14,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 4.52
+      "duration_hours": 4.52,
+      "legacy_ksi_id": "KSI-CNA-07"
     },
     {
-      "ksi_id": "KSI-IAM-01",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2026-03-11T03:52:46.025658Z",
       "failed_commit": "0f3a915976edbec0f3c3ed7a5c5bbdc7a2dd0d4e",
       "reason": "Insufficient (0%): Enforce multi-factor authentication (MFA) using methods that are difficult to intercept or impersonate (phishing-resi... | 0/1 resources compliant. | Warnings: IAM resource type 'unknown' has no specific evaluation rule (manual review required).",
@@ -5152,10 +5579,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 4.52
+      "duration_hours": 4.52,
+      "legacy_ksi_id": "KSI-IAM-01"
     },
     {
-      "ksi_id": "KSI-IAM-04",
+      "ksi_id": "KSI-IAM-JIT",
       "failed_at": "2026-03-11T03:52:46.025658Z",
       "failed_commit": "0f3a915976edbec0f3c3ed7a5c5bbdc7a2dd0d4e",
       "reason": "Insufficient (0%): Require a centralized identity management system. | 0/1 resources compliant. | Warnings: IAM resource type 'unknown' has no specific evaluation rule (manual review required).",
@@ -5165,10 +5593,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 4.52
+      "duration_hours": 4.52,
+      "legacy_ksi_id": "KSI-IAM-04"
     },
     {
-      "ksi_id": "KSI-INR-01",
+      "ksi_id": "KSI-INR-RIR",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (0%): Persistently review of the effectiveness of documented incident response procedures. | 0/3 resources compliant. | Failures: Governance document 'None' exists in CodeCommit but is EMPTY (0 bytes).; Governance document 'None' exists in CodeCommit but is EMPTY (0 bytes).; Governance document 'None' exists in CodeCommit but is EMPTY (0 bytes).",
@@ -5178,10 +5607,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 1.56
+      "duration_hours": 1.56,
+      "legacy_ksi_id": "KSI-INR-01"
     },
     {
-      "ksi_id": "KSI-INR-03",
+      "ksi_id": "KSI-INR-AAR",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (0%): Generate incident after action reports and persistently incorporate lessons learned. | 0/1 resources compliant. | Failures: Governance artifact 'None' exists in CodeCommit but is EMPTY (0 bytes).",
@@ -5191,10 +5621,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 1.56
+      "duration_hours": 1.56,
+      "legacy_ksi_id": "KSI-INR-03"
     },
     {
-      "ksi_id": "KSI-MLA-05",
+      "ksi_id": "KSI-MLA-EVC",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (8%): Persistently evaluate and test the configuration of machine-based information resources, especially infrastructure as... | 1/12 resources compliant. | Verified: Active: 1 resource(s) verified for 'None'. | Failures: Governance artifact 'None' exists in CodeCommit but is EMPTY (0 bytes).; Governance artifact 'None' exists in CodeCommit but is EMPTY (0 bytes).; Governance artifact 'None' exists in CodeCommit but is EMPTY (0 bytes). |   ...and 8 more failure(s)",
@@ -5204,10 +5635,11 @@
       "score_at_failure": 8,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 1.56
+      "duration_hours": 1.56,
+      "legacy_ksi_id": "KSI-MLA-05"
     },
     {
-      "ksi_id": "KSI-MLA-08",
+      "ksi_id": "KSI-MLA-ALA",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (0%): Use a least-privileged, role and attribute-based, and just-in-time access authorization model for access to log data. | 0/7 resources compliant. | Warnings: Service check for 'unknown': unable to determine specific compliance (manual review).; Service check for 'unknown': unable to determine specific compliance (manual review). |   ...and 5 more warning(s)",
@@ -5217,10 +5649,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 1.56
+      "duration_hours": 1.56,
+      "legacy_ksi_id": "KSI-MLA-08"
     },
     {
-      "ksi_id": "KSI-PIY-03",
+      "ksi_id": "KSI-PIY-RVD",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (0%): Persistently review the effectiveness of the providers vulnerability disclosure program. | 0/1 resources compliant. | Failures: Governance document 'None' exists in CodeCommit but is EMPTY (0 bytes).",
@@ -5230,10 +5663,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 1.56
+      "duration_hours": 1.56,
+      "legacy_ksi_id": "KSI-PIY-03"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (66%): Persistently review desired Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO). | 2/3 resources compliant. | Verified: Backup Plan 'rds-backup-plan' active (Recovery capability verified).; Backup Plan 'complete-backup-plan' active (Recovery capability verified). | Failures: Governance document 'None' exists in CodeCommit but is EMPTY (0 bytes).",
@@ -5243,10 +5677,11 @@
       "score_at_failure": 66,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 1.56
+      "duration_hours": 1.56,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (75%): Persistently review the alignment of machine-based information resource backups with defined recovery objectives. | 3/4 resources compliant. | Verified: Backup Plan 'unknown-backup-plan' active (Recovery capability verified). | Failures: Governance artifact 'None' exists in CodeCommit but is EMPTY (0 bytes).",
@@ -5256,10 +5691,11 @@
       "score_at_failure": 75,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 1.56
+      "duration_hours": 1.56,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (75%): Persistently test the capability to recover from incidents and contingencies, including alignment with defined recove... | 3/4 resources compliant. | Verified: Backup Plan 'unknown-backup-plan' active (Recovery capability verified). | Failures: Governance artifact 'None' exists in CodeCommit but is EMPTY (0 bytes).",
@@ -5269,10 +5705,11 @@
       "score_at_failure": 75,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 1.56
+      "duration_hours": 1.56,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
-      "ksi_id": "KSI-SVC-06",
+      "ksi_id": "KSI-SVC-ASM",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (73%): Automate management, protection, and regular rotation of digital keys, certificates, and other secrets. | 11/15 resources compliant. | Verified: Active: 1 resource(s) verified for 'None'.; TLS infrastructure: 1 ACM certificate(s) available for encryption in transit. | Warnings: No secrets found in Secrets Manager.; No secrets found in Secrets Manager. |   ...and 2 more warning(s)",
@@ -5282,10 +5719,11 @@
       "score_at_failure": 73,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 1.56
+      "duration_hours": 1.56,
+      "legacy_ksi_id": "KSI-SVC-06"
     },
     {
-      "ksi_id": "KSI-TPR-03",
+      "ksi_id": "KSI-SCR-MIT",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (2%): Persistently identify, review, and mitigate potential supply chain risks. | 1/48 resources compliant. | Verified: Verified: Governance document 'security-governance' is substantive (3847 bytes, 10 sections). | Failures: Governance document 'None' exists in CodeCommit but is EMPTY (0 bytes).; Governance document 'None' exists in CodeCommit but is EMPTY (0 bytes).; Governance document 'None' exists in CodeCommit but is EMPTY (0 bytes). |   ...and 43 more failure(s) | Warnings: Governance artifact 'Unidentified_Item_fb24ee8f' exists but appears minimal (38 bytes). May lack sufficient governance detail.",
@@ -5295,10 +5733,11 @@
       "score_at_failure": 2,
       "remediated_at": "2026-03-11T08:24:03.715730Z",
       "remediation_commit": "1fc7559842fd16428fb850ecd26bfcab595a1bca",
-      "duration_hours": 1.56
+      "duration_hours": 1.56,
+      "legacy_ksi_id": "KSI-TPR-03"
     },
     {
-      "ksi_id": "KSI-IAM-02",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2026-03-11T03:52:46.025658Z",
       "failed_commit": "0f3a915976edbec0f3c3ed7a5c5bbdc7a2dd0d4e",
       "reason": "Insufficient (0%): Use secure passwordless methods for user authentication and authorization when feasible, otherwise enforce strong pas... | 0/3 resources compliant. | Warnings: IAM resource type 'unknown' has no specific evaluation rule (manual review required).; IAM resource type 'unknown' has no specific evaluation rule (manual review required). |   ...and 1 more warning(s)",
@@ -5308,10 +5747,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-03-11T10:13:29.444510Z",
       "remediation_commit": "a98864c554bed3904a107476fc456d98283c6c45",
-      "duration_hours": 6.35
+      "duration_hours": 6.35,
+      "legacy_ksi_id": "KSI-IAM-02"
     },
     {
-      "ksi_id": "KSI-IAM-05",
+      "ksi_id": "KSI-IAM-ELP",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (0%): Persistently ensure that identity and access management employs measures to ensure each user or device can only acces... | 0/2 resources compliant. | Warnings: IAM resource type 'unknown' has no specific evaluation rule (manual review required).; IAM resource type 'unknown' has no specific evaluation rule (manual review required).",
@@ -5321,10 +5761,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-03-11T10:13:29.444510Z",
       "remediation_commit": "a98864c554bed3904a107476fc456d98283c6c45",
-      "duration_hours": 3.38
+      "duration_hours": 3.38,
+      "legacy_ksi_id": "KSI-IAM-05"
     },
     {
-      "ksi_id": "KSI-IAM-07",
+      "ksi_id": "KSI-IAM-AAM",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (0%): Securely manage the lifecycle and privileges of all accounts, roles, and groups, using automation. | 0/1 resources compliant. | Warnings: IAM resource type 'unknown' has no specific evaluation rule (manual review required).",
@@ -5334,10 +5775,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-03-11T10:13:29.444510Z",
       "remediation_commit": "a98864c554bed3904a107476fc456d98283c6c45",
-      "duration_hours": 3.38
+      "duration_hours": 3.38,
+      "legacy_ksi_id": "KSI-IAM-07"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (15%): Persistently review past incidents for patterns or vulnerabilities. | 2/13 resources compliant. | Verified: Active: 1 resource(s) verified for 'aws-quicksetup-patchpolicy-access-log-893894210484-83f5-4o02l'.; Active: 1 resource(s) verified for 'security-artifacts-bucket-893894210484'. | Warnings: Logging resource type 'None' has no specific evaluation rule (manual review required).; Logging resource type 'None' has no specific evaluation rule (manual review required). |   ...and 9 more warning(s)",
@@ -5347,10 +5789,11 @@
       "score_at_failure": 15,
       "remediated_at": "2026-03-11T10:13:29.444510Z",
       "remediation_commit": "a98864c554bed3904a107476fc456d98283c6c45",
-      "duration_hours": 3.38
+      "duration_hours": 3.38,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
-      "ksi_id": "KSI-MLA-07",
+      "ksi_id": "KSI-MLA-LET",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (18%): Maintain a list of information resources and event types that will be monitored, logged, and audited. | 2/11 resources compliant. | Verified: SSM inventory: 1 managed instance(s) reporting OS/software data.; Trail is Secure (Multi-Region, Validated, Encrypted) | Warnings: Logging resource type 'None' has no specific evaluation rule (manual review required).; Logging resource type 'None' has no specific evaluation rule (manual review required). |   ...and 7 more warning(s)",
@@ -5360,10 +5803,11 @@
       "score_at_failure": 18,
       "remediated_at": "2026-03-11T10:13:29.444510Z",
       "remediation_commit": "a98864c554bed3904a107476fc456d98283c6c45",
-      "duration_hours": 3.38
+      "duration_hours": 3.38,
+      "legacy_ksi_id": "KSI-MLA-07"
     },
     {
-      "ksi_id": "KSI-CNA-02",
+      "ksi_id": "KSI-CNA-MAT",
       "failed_at": "2026-03-11T03:52:46.025658Z",
       "failed_commit": "0f3a915976edbec0f3c3ed7a5c5bbdc7a2dd0d4e",
       "reason": "Good (86%): Persistently ensure machine-based information resources have a minimal attack surface and that lateral movement is mi... | 19/22 resources compliant. CRITICAL OVERRIDE: Open ingress (0.0.0.0/0) on EC2. | Verified: Private Subnet: 'mksfr-private-utility-subnet-a' has public IP mapping disabled (attack surface minimized).; Private Subnet: 'mksfr-private-subnet-a' has public IP mapping disabled (attack surface minimized).; Private Subnet: 'mksfr-firewall-subnet-a' has public IP mapping disabled (attack surface minimized). |   ...and 16 more verification(s) | Failures:  CRITICAL: Critical findings detected: Open ingress (0.0.0.0/0) on EC2 | Warnings: Best Practice: SG 'launch-wizard-2' uses broad CIDRs (10.0.0.0/8 (TCP 22-22)). Consider more specific ranges or Security Group references for tighter segmentation.; Best Practice: SG 'mksfr-proxy-sg1' uses broad CIDRs (10.0.0.0/8 (TCP 3129-3129), 10.0.0.0/8 (TCP 3128-3128), 10.0.0.0/8 (ICMP -1--1)). Consider more specific ranges or Security Group references for tighter segmentation.",
@@ -5373,10 +5817,11 @@
       "score_at_failure": 86,
       "remediated_at": "2026-03-11T21:10:26.325495Z",
       "remediation_commit": "b4648423e32c0d3aacf3b5df5fe9c25b4f3cddf0",
-      "duration_hours": 17.29
+      "duration_hours": 17.29,
+      "legacy_ksi_id": "KSI-CNA-02"
     },
     {
-      "ksi_id": "KSI-MLA-02",
+      "ksi_id": "KSI-MLA-RVL",
       "failed_at": "2026-03-11T06:50:28.470258Z",
       "failed_commit": "bbe416d3a48f95d54651bc57cb5b8c1bb51f91f2",
       "reason": "Insufficient (16%): Persistently review and audit logs. | 1/6 resources compliant. | Verified: Active: 1 resource(s) verified for 'Critical Findings'. | Warnings: Service check for 'None': unable to determine specific compliance (manual review).; Service check for 'None': unable to determine specific compliance (manual review). |   ...and 3 more warning(s)",
@@ -5386,10 +5831,11 @@
       "score_at_failure": 16,
       "remediated_at": "2026-03-11T21:10:26.325495Z",
       "remediation_commit": "b4648423e32c0d3aacf3b5df5fe9c25b4f3cddf0",
-      "duration_hours": 14.33
+      "duration_hours": 14.33,
+      "legacy_ksi_id": "KSI-MLA-02"
     },
     {
-      "ksi_id": "KSI-IAM-01",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2026-05-12T03:32:20.343469+00:00",
       "failed_commit": "be8e9a4031be878993ed927ae57079736ec6ade2",
       "reason": "Excellent (91%): Enforce multi-factor authentication (MFA) using methods that are difficult to intercept or impersonate (phishing-resi... | 11/14 resources compliant, 2 unverified. | Verified: Modern Identity: AWS Identity Center is active.; Inspector scanning 1 resource(s) for vulnerabilities. | Failures: Required infrastructure not found: Permission sets with SessionDuration; primitive computes within_target_rate; auditor reviews exceeding_sets",
@@ -5399,10 +5845,11 @@
       "score_at_failure": 91,
       "remediated_at": "2026-05-12T06:27:58.065457+00:00",
       "remediation_commit": "5d2bff5f403d1480ef802cb63492fec5bafbc888",
-      "duration_hours": 2.93
+      "duration_hours": 2.93,
+      "legacy_ksi_id": "KSI-IAM-01"
     },
     {
-      "ksi_id": "KSI-SVC-04",
+      "ksi_id": "KSI-SVC-ACM",
       "failed_at": "2026-05-12T03:06:48.256462+00:00",
       "failed_commit": "5fe128e1ff844263ab7f67b57fac4c969bf08226",
       "reason": "Insufficient (50%): Manage configuration of machine-based information resources using automation. | 1/4 resources compliant, 2 unverified. | Verified: Verified: Governance document '[resource]' is substantive (1070 bytes, 4 sections). | Failures: Patch compliance 0% < target 95% (0 non-compliant).",
@@ -5412,10 +5859,11 @@
       "score_at_failure": 50,
       "remediated_at": "2026-05-12T06:27:58.065457+00:00",
       "remediation_commit": "5d2bff5f403d1480ef802cb63492fec5bafbc888",
-      "duration_hours": 3.35
+      "duration_hours": 3.35,
+      "legacy_ksi_id": "KSI-SVC-04"
     },
     {
-      "ksi_id": "KSI-CMT-01",
+      "ksi_id": "KSI-CMT-LMC",
       "failed_at": "2026-05-12T03:32:20.343469+00:00",
       "failed_commit": "be8e9a4031be878993ed927ae57079736ec6ade2",
       "reason": "Insufficient (80%): Log and monitor modifications to the cloud service offering. | 4/5 resources compliant. | Verified: Trail is Secure (Multi-Region, Validated, KMS-Encrypted, Global Events); Trail captures management events (1 selectors) (S3 data events captured).; Active: 1 resource(s) verified for '[resource]'. |   ...and 1 more verification(s) | Failures: No Inspector coverage. Vulnerability scanning is not active.",
@@ -5425,10 +5873,11 @@
       "score_at_failure": 80,
       "remediated_at": "2026-05-12T07:07:28.125631+00:00",
       "remediation_commit": "a8708b680a60e29a0479d9ccb16ab5bcdfe1a129",
-      "duration_hours": 3.59
+      "duration_hours": 3.59,
+      "legacy_ksi_id": "KSI-CMT-01"
     },
     {
-      "ksi_id": "KSI-IAM-04",
+      "ksi_id": "KSI-IAM-JIT",
       "failed_at": "2026-05-12T03:32:20.343469+00:00",
       "failed_commit": "be8e9a4031be878993ed927ae57079736ec6ade2",
       "reason": "Insufficient (0%): Require a centralized identity management system. | 1/110 resources compliant, 1 unverified. | Verified: Modern Identity: AWS Identity Center is active. | Warnings: No SSM inventory data available for managed instances.; No SSM inventory data available for managed instances. |   ...and 106 more warning(s)",
@@ -5438,10 +5887,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-05-12T07:07:28.125631+00:00",
       "remediation_commit": "a8708b680a60e29a0479d9ccb16ab5bcdfe1a129",
-      "duration_hours": 3.59
+      "duration_hours": 3.59,
+      "legacy_ksi_id": "KSI-IAM-04"
     },
     {
-      "ksi_id": "KSI-SVC-02",
+      "ksi_id": "KSI-SVC-SIN",
       "failed_at": "2026-05-12T02:05:48.594639+00:00",
       "failed_commit": "710af8e2364f6b7df16166e893acd92fcf106033",
       "reason": "Insufficient (66%): Encrypt or otherwise secure network traffic. | 4/7 resources compliant, 1 unverified. | Verified: ACM certificate for '*.[internal-domain]' (ISSUED).; Active: 1 resource(s) verified for '[resource]'.; Verified: Governance document '[resource]' is substantive (594 bytes, 4 sections). | Warnings: Service check for 'ELB TLS Listener Coverage Metrics': unable to determine specific compliance (manual review).; Service check for 'ELB TLS Listener Coverage Metrics': unable to determine specific compliance (manual review).",
@@ -5451,10 +5901,11 @@
       "score_at_failure": 66,
       "remediated_at": "2026-05-12T07:07:28.125631+00:00",
       "remediation_commit": "a8708b680a60e29a0479d9ccb16ab5bcdfe1a129",
-      "duration_hours": 5.03
+      "duration_hours": 5.03,
+      "legacy_ksi_id": "KSI-SVC-02"
     },
     {
-      "ksi_id": "KSI-MLA-07",
+      "ksi_id": "KSI-MLA-LET",
       "failed_at": "2026-05-12T07:07:28.125631+00:00",
       "failed_commit": "a8708b680a60e29a0479d9ccb16ab5bcdfe1a129",
       "reason": "Excellent (91%): Maintain a list of information resources and event types that will be monitored, logged, and audited. | 11/12 resources compliant. | Verified: SSM inventory: 1 managed instance(s) reporting OS/software data.; Trail is Secure (Multi-Region, Validated, KMS-Encrypted, Global Events); Log group '[resource]': retention 365d meets documented log retention policy (\u2265365d) (AWS-managed FIPS key). |   ...and 8 more verification(s) | Failures: RDS audit-log export rate 50% < target 100% (1/2 DB instances without audit log export \u2014 sample: stage(sqlserver-se)). Bulk message-table reads leave no DB-side audit trail.",
@@ -5464,10 +5915,11 @@
       "score_at_failure": 91,
       "remediated_at": "2026-05-13T17:16:14.508436+00:00",
       "remediation_commit": "c6e450bed844c4a2fa25f3c7cfb51815ae1fa8cc",
-      "duration_hours": 34.15
+      "duration_hours": 34.15,
+      "legacy_ksi_id": "KSI-MLA-07"
     },
     {
-      "ksi_id": "KSI-MLA-01",
+      "ksi_id": "KSI-MLA-OSM",
       "failed_at": "2026-05-12T03:32:20.343469+00:00",
       "failed_commit": "be8e9a4031be878993ed927ae57079736ec6ade2",
       "reason": "Insufficient (13%): Log all activity on all information resources supporting the cloud service offering to a protected audit log. | 2/16 resources compliant, 1 unverified. | Verified: Trail is Secure (Multi-Region, Validated, KMS-Encrypted, Global Events); No SES identities (email not used by service). Anti-spoofing N/A. | Failures: Bucket 'S3 Bucket Access Logging Coverage' has public-exposure vectors: no PublicAccessBlockConfiguration returned (cannot confirm blocked).; Bucket 'S3 Bucket Access Logging Coverage' has public-exposure vectors: no PublicAccessBlockConfiguration returned (cannot confirm blocked).; Bucket 'S3 Bucket Access Logging Coverage' has public-exposure vectors: no PublicAccessBlockConfiguration returned (cannot confirm blocked). |   ...and 10 more failure(s)",
@@ -5477,10 +5929,11 @@
       "score_at_failure": 13,
       "remediated_at": "2026-05-14T17:08:02.244825+00:00",
       "remediation_commit": "7416cfac7d250ac7d52e3aacfa07c8c877a3849c",
-      "duration_hours": 61.59
+      "duration_hours": 61.59,
+      "legacy_ksi_id": "KSI-MLA-01"
     },
     {
-      "ksi_id": "KSI-INR-03",
+      "ksi_id": "KSI-INR-AAR",
       "failed_at": "2026-05-12T01:31:01.800902+00:00",
       "failed_commit": "0efea34406d09084d101fde7073eed0ffd31b9de",
       "reason": "Insufficient (50%): Generate incident after action reports and persistently incorporate lessons learned. | 1/2 resources compliant. | Verified: Active: 1 resource(s) verified for '[resource]'. | Failures: MTTR 3598.5h > target 72h (60/100 resolved).",
@@ -5490,10 +5943,11 @@
       "score_at_failure": 50,
       "remediated_at": "2026-05-15T13:06:09.153821+00:00",
       "remediation_commit": "4c984ab251b2f712ec97cdd982c078e37337b8f1",
-      "duration_hours": 83.59
+      "duration_hours": 83.59,
+      "legacy_ksi_id": "KSI-INR-03"
     },
     {
-      "ksi_id": "KSI-AFR-11",
+      "ksi_id": "FRR-CMU",
       "failed_at": "2026-05-12T07:07:28.125631+00:00",
       "failed_commit": "a8708b680a60e29a0479d9ccb16ab5bcdfe1a129",
       "reason": "Excellent (96%): Ensure that cryptographic modules are selected and used in alignment with the FedRAMP 20x Using Cryptographic Modules... | 28/31 resources compliant, 2 unverified. | Verified: KMS key '[resource]' present (FIPS-validated KMS HSM).; S3 bucket '[resource]' encrypted with AES256 (SSE-S3, AWS-managed); BucketKeyEnabled=False.; RDS instance '[resource]' is encrypted with FIPS-validated KMS module (customer-managed CMK): arn:aws:[redacted] |   ...and 3 more verification(s) | Warnings: KMS coverage 7% < target 100% (13/14 buckets on SSE-S3 / AES256 not FIPS-validated CMK path).",
@@ -5503,10 +5957,11 @@
       "score_at_failure": 96,
       "remediated_at": "2026-05-18T15:00:06.097008+00:00",
       "remediation_commit": "8a4a0aef378415718ec62a1164624418e7b05cdf",
-      "duration_hours": 151.88
+      "duration_hours": 151.88,
+      "legacy_ksi_id": "KSI-AFR-11"
     },
     {
-      "ksi_id": "KSI-SVC-06",
+      "ksi_id": "KSI-SVC-ASM",
       "failed_at": "2026-05-12T02:05:48.594639+00:00",
       "failed_commit": "710af8e2364f6b7df16166e893acd92fcf106033",
       "reason": "Insufficient (36%): Automate management, protection, and regular rotation of digital keys, certificates, and other secrets. | 13/36 resources compliant. | Verified: Active: 1 resource(s) verified for '[resource]'.; Secret '[resource]' has auto-rotation enabled.; ACM certificate for '*.[internal-domain]' (ISSUED). | Failures: Secret '[resource]' has RotationEnabled=False \u2014 FedRAMP SC-12(c) requires rotation.; Secret '[resource]' has RotationEnabled=False \u2014 FedRAMP SC-12(c) requires rotation.; Secret '[resource]' has RotationEnabled=False \u2014 FedRAMP SC-12(c) requires rotation. |   ...and 20 more failure(s)",
@@ -5516,10 +5971,11 @@
       "score_at_failure": 36,
       "remediated_at": "2026-05-18T15:00:06.097008+00:00",
       "remediation_commit": "8a4a0aef378415718ec62a1164624418e7b05cdf",
-      "duration_hours": 156.9
+      "duration_hours": 156.9,
+      "legacy_ksi_id": "KSI-SVC-06"
     },
     {
-      "ksi_id": "KSI-SVC-05",
+      "ksi_id": "KSI-SVC-VRI",
       "failed_at": "2026-05-11T23:48:15.169562+00:00",
       "failed_commit": "347dea29ffb2add235bcde25a55de977f4c0ecaf",
       "reason": "Insufficient (0%): Use cryptographic methods to validate the integrity of machine-based information resources. | 8/9 resources compliant. | Verified: Active: 1 resource(s) verified for '[resource]'.; No SES identities (email not used by service). Anti-spoofing N/A. | Failures: Required infrastructure not found: CloudTrail LogFileValidationEnabled must be true",
@@ -5529,10 +5985,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-05-18T19:26:46.554176+00:00",
       "remediation_commit": "3b6063efcfab03f62cf5cabb0f927c1163bca322",
-      "duration_hours": 163.64
+      "duration_hours": 163.64,
+      "legacy_ksi_id": "KSI-SVC-05"
     },
     {
-      "ksi_id": "KSI-CMT-03",
+      "ksi_id": "KSI-CMT-VTD",
       "failed_at": "2026-05-12T01:31:01.800902+00:00",
       "failed_commit": "0efea34406d09084d101fde7073eed0ffd31b9de",
       "reason": "Insufficient (87%): Automate persistent testing and validation of changes throughout deployment. | 7/8 resources compliant. | Verified: Active: 1 resource(s) verified for '[resource]'.; Active Config rule: securityhub-access-keys-rotated-7a4c00b0.; Active Config rule: securityhub-acm-certificate-expiration-check-0418f14d. |   ...and 4 more verification(s) | Failures: Config drift 48% > 5% target (59 non-compliant rules).",
@@ -5542,10 +5999,11 @@
       "score_at_failure": 87,
       "remediated_at": "2026-05-18T20:08:26.846705+00:00",
       "remediation_commit": "f48be46921b34ff9b8a1f157704f372d43cd816e",
-      "duration_hours": 162.62
+      "duration_hours": 162.62,
+      "legacy_ksi_id": "KSI-CMT-03"
     },
     {
-      "ksi_id": "KSI-INR-03",
+      "ksi_id": "KSI-INR-AAR",
       "failed_at": "2026-05-15T17:03:07.862552+00:00",
       "failed_commit": "f149bfbe16210275ace5dc8e9339c8bc9136b675",
       "reason": "Insufficient (50%): Generate incident after action reports and persistently incorporate lessons learned. | 1/2 resources compliant. | Verified: Active: 1 resource(s) verified for '[resource]'. | Failures: MTTR 816.4h > target 72h (77/100 resolved).",
@@ -5555,10 +6013,11 @@
       "score_at_failure": 50,
       "remediated_at": "2026-05-18T20:08:26.846705+00:00",
       "remediation_commit": "f48be46921b34ff9b8a1f157704f372d43cd816e",
-      "duration_hours": 75.09
+      "duration_hours": 75.09,
+      "legacy_ksi_id": "KSI-INR-03"
     },
     {
-      "ksi_id": "KSI-AFR-08",
+      "ksi_id": "FRR-AFC",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Insufficient (75%): Operate a secure inbox to receive critical communication from FedRAMP and other government entities. | 3/4 resources compliant. | Verified: Alert infrastructure: SNS resource '[resource]' configured.; Alert infrastructure: SNS resource '[resource]' configured.; Alert infrastructure: SNS resource '[resource]' configured. | Failures: Governance document '[resource]' exists in CodeCommit but is EMPTY (0 bytes). | Verdict: Score 75% below threshold 80% (3 pass / 1 fail / 0 warning / 0 unverified).",
@@ -5568,10 +6027,11 @@
       "score_at_failure": 75,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-AFR-08"
     },
     {
-      "ksi_id": "KSI-AFR-09",
+      "ksi_id": "FRR-SDR",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Insufficient (50%): Persistently validate security posture using automated pipelines. | 1/2 resources compliant. | Verified: Validation artifact '[resource]' exists, size: 387 KB, freshness: current (0d), versioned. | Failures: Governance document '[resource]' exists in CodeCommit but is EMPTY (0 bytes). | Verdict: Score 50% below threshold 80% (1 pass / 1 fail / 0 warning / 0 unverified).",
@@ -5581,10 +6041,11 @@
       "score_at_failure": 50,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-AFR-09"
     },
     {
-      "ksi_id": "KSI-AFR-10",
+      "ksi_id": "FRR-IEC",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Insufficient (66%): Integrate FedRAMP's Incident Communications Procedures (ICP) into incident response procedures and infrastructure. | 4/7 resources compliant, 1 unverified. | Verified: Alert infrastructure: SNS resource '[resource]' configured.; Alert infrastructure: SNS resource '[resource]' configured.; Alert infrastructure: SNS resource '[resource]' configured. |   ...and 1 more verification(s) | Failures: Governance document '[resource]' exists in CodeCommit but is EMPTY (0 bytes).; Governance document '[resource]' exists in CodeCommit but is EMPTY (0 bytes). | Verdict: Score 66% below threshold 80% (4 pass / 2 fail / 0 warning / 1 unverified).",
@@ -5594,10 +6055,11 @@
       "score_at_failure": 66,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-AFR-10"
     },
     {
-      "ksi_id": "KSI-AFR-11",
+      "ksi_id": "FRR-CMU",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Insufficient (96%): Ensure that cryptographic modules are selected and used in alignment with the FedRAMP 20x Using Cryptographic Modules... | 26/30 resources compliant, 2 unverified. | Verified: KMS key '[resource]' present (FIPS-validated KMS HSM).; S3 bucket '[resource]' encrypted with AES256 (SSE-S3, AWS-managed); BucketKeyEnabled=False.; RDS instance '[resource]' is encrypted with FIPS-validated KMS module (customer-managed CMK): arn:aws:[redacted] |   ...and 1 more verification(s) | Failures: Governance document '[resource]' exists in CodeCommit but is EMPTY (0 bytes). | Warnings: KMS coverage 7% < target 100% (13/14 buckets on SSE-S3 / AES256 not FIPS-validated CMK path). | Verdict: Score 96% below threshold 100%.",
@@ -5607,10 +6069,11 @@
       "score_at_failure": 96,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-AFR-11"
     },
     {
-      "ksi_id": "KSI-CED-01",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Insufficient (0%): Persistently review the effectiveness of training given to all employees on policies, procedures, and security-relate... | 0/2 resources compliant. | Warnings: Training register '[resource]' exists but content could not be parsed. Unable to verify training effectiveness.; Training curriculum '[resource]' exists but content is empty or inaccessible. | Verdict: Score 0% below threshold 80% (0 pass / 0 fail / 2 warning / 0 unverified).",
@@ -5620,10 +6083,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-CED-01"
     },
     {
-      "ksi_id": "KSI-CED-02",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Insufficient (0%): Persistently review the effectiveness of role-specific training given to employees in high risk roles, including at l... | 0/2 resources compliant. | Warnings: Training register '[resource]' exists but content could not be parsed. Unable to verify training effectiveness.; Training curriculum '[resource]' exists but content is empty or inaccessible. | Verdict: Score 0% below threshold 80% (0 pass / 0 fail / 2 warning / 0 unverified).",
@@ -5633,10 +6097,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-CED-02"
     },
     {
-      "ksi_id": "KSI-CED-03",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Insufficient (0%): Persistently review the effectiveness of role-specific training given to development and engineering staff that cover... | 0/2 resources compliant. | Warnings: Training register '[resource]' exists but content could not be parsed. Unable to verify training effectiveness.; Training curriculum '[resource]' exists but content is empty or inaccessible. | Verdict: Score 0% below threshold 80% (0 pass / 0 fail / 2 warning / 0 unverified).",
@@ -5646,10 +6111,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-CED-03"
     },
     {
-      "ksi_id": "KSI-CED-04",
+      "ksi_id": "KSI-CED-RAT",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Insufficient (0%): Persistently review the effectiveness of role-specific training given to staff involved with incident response or dis... | 0/2 resources compliant. | Warnings: Training register '[resource]' exists but content could not be parsed. Unable to verify training effectiveness.; Training curriculum '[resource]' exists but content is empty or inaccessible. | Verdict: Score 0% below threshold 80% (0 pass / 0 fail / 2 warning / 0 unverified).",
@@ -5659,10 +6125,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-CED-04"
     },
     {
-      "ksi_id": "KSI-CMT-01",
+      "ksi_id": "KSI-CMT-LMC",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Insufficient (75%): Log and monitor modifications to the cloud service offering. | 3/5 resources compliant, 1 unverified. | Verified: Trail is Secure (Multi-Region, Validated, KMS-Encrypted, Global Events); Trail captures management events (1 selectors) (S3 data events captured).; 1/1 trail(s) capture S3 data events (object-level read/write audit trail present). | Failures: Governance document '[resource]' exists in CodeCommit but is EMPTY (0 bytes). | Verdict: Score 75% below threshold 100%.",
@@ -5672,10 +6139,11 @@
       "score_at_failure": 75,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-CMT-01"
     },
     {
-      "ksi_id": "KSI-CMT-03",
+      "ksi_id": "KSI-CMT-VTD",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Insufficient (83%): Automate persistent testing and validation of changes throughout deployment. | 5/8 resources compliant, 1 unverified. | Verified: Active Config rule: securityhub-access-keys-rotated-7a4c00b0.; Active Config rule: securityhub-acm-certificate-expiration-check-0418f14d.; Active Config rule: securityhub-acm-certificate-rsa-check-572cb268. |   ...and 2 more verification(s) | Failures: Governance document '[resource]' exists in CodeCommit but is EMPTY (0 bytes).; Config drift 43% > 5% target (52 non-compliant rules). | Verdict: Score 83% below threshold 100%.",
@@ -5685,10 +6153,11 @@
       "score_at_failure": 83,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-CMT-03"
     },
     {
-      "ksi_id": "KSI-CMT-04",
+      "ksi_id": "KSI-CMT-RVP",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Insufficient (0%): Persistently review the effectiveness of documented change management procedures. | 0/2 resources compliant, 1 unverified. | Failures: Governance document '[resource]' exists in CodeCommit but is EMPTY (0 bytes). | Verdict: Score 0% below threshold 100% (0 pass / 1 fail / 0 warning / 1 unverified).",
@@ -5698,10 +6167,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-CMT-04"
     },
     {
-      "ksi_id": "KSI-CNA-03",
+      "ksi_id": "KSI-CNA-ULN",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Use logical networking and related capabilities to enforce traffic flow controls. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5711,10 +6181,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-CNA-03"
     },
     {
-      "ksi_id": "KSI-CNA-07",
+      "ksi_id": "KSI-CNA-IBP",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently ensure cloud-native machine-based information resources are implemented based on the host providers best... | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5724,10 +6195,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-CNA-07"
     },
     {
-      "ksi_id": "KSI-IAM-02",
+      "ksi_id": "KSI-IAM-APM",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Use secure passwordless methods for user authentication and authorization when feasible, otherwise enforce strong pas... | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5737,10 +6209,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-IAM-02"
     },
     {
-      "ksi_id": "KSI-IAM-03",
+      "ksi_id": "KSI-IAM-SNU",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Enforce appropriately secure authentication methods for non-user accounts and services. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5750,10 +6223,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-IAM-03"
     },
     {
-      "ksi_id": "KSI-IAM-04",
+      "ksi_id": "KSI-IAM-JIT",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Require a centralized identity management system. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: Required operational metric(s) not measured this run: cross_account_trust_metrics No findings produced for this KSI.",
@@ -5763,10 +6237,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-IAM-04"
     },
     {
-      "ksi_id": "KSI-IAM-05",
+      "ksi_id": "KSI-IAM-ELP",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently ensure that identity and access management employs measures to ensure each user or device can only acces... | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5776,10 +6251,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-IAM-05"
     },
     {
-      "ksi_id": "KSI-INR-02",
+      "ksi_id": "KSI-INR-RPI",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently review past incidents for patterns or vulnerabilities. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5789,10 +6265,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-INR-02"
     },
     {
-      "ksi_id": "KSI-MLA-01",
+      "ksi_id": "KSI-MLA-OSM",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Log all activity on all information resources supporting the cloud service offering to a protected audit log. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: Required operational metric(s) not measured this run: trail_logging_metrics, s3_logging_coverage_metrics, alb_access_log_metrics No findings produced for this KSI.",
@@ -5802,10 +6279,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-MLA-01"
     },
     {
-      "ksi_id": "KSI-MLA-07",
+      "ksi_id": "KSI-MLA-LET",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Maintain a list of information resources and event types that will be monitored, logged, and audited. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: Required operational metric(s) not measured this run: rds_audit_log_metrics No findings produced for this KSI.",
@@ -5815,10 +6293,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-MLA-07"
     },
     {
-      "ksi_id": "KSI-PIY-03",
+      "ksi_id": "KSI-PIY-RVD",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently review the effectiveness of the providers vulnerability disclosure program. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5828,10 +6307,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-PIY-03"
     },
     {
-      "ksi_id": "KSI-PIY-04",
+      "ksi_id": "KSI-PIY-RSD",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently review the effectiveness of building security and privacy considerations into the Software Development L... | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5841,10 +6321,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-PIY-04"
     },
     {
-      "ksi_id": "KSI-PIY-06",
+      "ksi_id": "KSI-PIY-RIS",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently review the effectiveness of the organizations investments in achieving security objectives. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5854,10 +6335,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-PIY-06"
     },
     {
-      "ksi_id": "KSI-RPL-01",
+      "ksi_id": "KSI-RPL-RRO",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently review desired Recovery Time Objectives (RTO) and Recovery Point Objectives (RPO). | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5867,10 +6349,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-RPL-01"
     },
     {
-      "ksi_id": "KSI-RPL-02",
+      "ksi_id": "KSI-RPL-ARP",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently review the alignment of recovery plans with defined recovery objectives. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: Required operational metric(s) not measured this run: backup_metrics No findings produced for this KSI.",
@@ -5880,10 +6363,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-RPL-02"
     },
     {
-      "ksi_id": "KSI-RPL-03",
+      "ksi_id": "KSI-RPL-ABO",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently review the alignment of machine-based information resource backups with defined recovery objectives. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: Required operational metric(s) not measured this run: backup_metrics No findings produced for this KSI.",
@@ -5893,10 +6377,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-RPL-03"
     },
     {
-      "ksi_id": "KSI-RPL-04",
+      "ksi_id": "KSI-RPL-TRC",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently test the capability to recover from incidents and contingencies, including alignment with defined recove... | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: Required operational metric(s) not measured this run: backup_metrics No findings produced for this KSI.",
@@ -5906,10 +6391,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-RPL-04"
     },
     {
-      "ksi_id": "KSI-SVC-02",
+      "ksi_id": "KSI-SVC-SIN",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Encrypt or otherwise secure network traffic. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: Required operational metric(s) not measured this run: tls_listener_metrics No findings produced for this KSI.",
@@ -5919,10 +6405,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-15T22:39:10.428202+00:00",
       "remediation_commit": "6c10bfd92d80da1a765612380f0523c5ee19be2e",
-      "duration_hours": 1.12
+      "duration_hours": 1.12,
+      "legacy_ksi_id": "KSI-SVC-02"
     },
     {
-      "ksi_id": "KSI-CNA-08",
+      "ksi_id": "KSI-CNA-EIS",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Use automated services to persistently assess the security posture of all machine-based information resources and aut... | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5932,10 +6419,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-16T21:54:01.560576+00:00",
       "remediation_commit": "a02eb7dfed1636cecb2e8acee82c62fd40b75e35",
-      "duration_hours": 24.37
+      "duration_hours": 24.37,
+      "legacy_ksi_id": "KSI-CNA-08"
     },
     {
-      "ksi_id": "KSI-IAM-06",
+      "ksi_id": "KSI-IAM-SUS",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Automatically disable or otherwise secure accounts with privileged access in response to suspicious activity | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5945,10 +6433,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-16T21:54:01.560576+00:00",
       "remediation_commit": "a02eb7dfed1636cecb2e8acee82c62fd40b75e35",
-      "duration_hours": 24.37
+      "duration_hours": 24.37,
+      "legacy_ksi_id": "KSI-IAM-06"
     },
     {
-      "ksi_id": "KSI-INR-01",
+      "ksi_id": "KSI-INR-RIR",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently review of the effectiveness of documented incident response procedures. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5958,10 +6447,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-16T21:54:01.560576+00:00",
       "remediation_commit": "a02eb7dfed1636cecb2e8acee82c62fd40b75e35",
-      "duration_hours": 24.37
+      "duration_hours": 24.37,
+      "legacy_ksi_id": "KSI-INR-01"
     },
     {
-      "ksi_id": "KSI-SVC-01",
+      "ksi_id": "KSI-SVC-EIS",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Implement improvements based on persistent evaluation of information resources for opportunities to improve security. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5971,10 +6461,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-16T21:54:01.560576+00:00",
       "remediation_commit": "a02eb7dfed1636cecb2e8acee82c62fd40b75e35",
-      "duration_hours": 24.37
+      "duration_hours": 24.37,
+      "legacy_ksi_id": "KSI-SVC-01"
     },
     {
-      "ksi_id": "KSI-SVC-05",
+      "ksi_id": "KSI-SVC-VRI",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Use cryptographic methods to validate the integrity of machine-based information resources. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5984,10 +6475,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-16T21:54:01.560576+00:00",
       "remediation_commit": "a02eb7dfed1636cecb2e8acee82c62fd40b75e35",
-      "duration_hours": 24.37
+      "duration_hours": 24.37,
+      "legacy_ksi_id": "KSI-SVC-05"
     },
     {
-      "ksi_id": "KSI-SVC-08",
+      "ksi_id": "KSI-SVC-PRR",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently review plans, procedures, and the state of information resources after making changes to limit and remov... | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -5997,10 +6489,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-16T21:54:01.560576+00:00",
       "remediation_commit": "a02eb7dfed1636cecb2e8acee82c62fd40b75e35",
-      "duration_hours": 24.37
+      "duration_hours": 24.37,
+      "legacy_ksi_id": "KSI-SVC-08"
     },
     {
-      "ksi_id": "KSI-SVC-09",
+      "ksi_id": "KSI-SVC-VCM",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently validate the authenticity and integrity of communications between machine-based information resources us... | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -6010,10 +6503,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-16T21:54:01.560576+00:00",
       "remediation_commit": "a02eb7dfed1636cecb2e8acee82c62fd40b75e35",
-      "duration_hours": 24.37
+      "duration_hours": 24.37,
+      "legacy_ksi_id": "KSI-SVC-09"
     },
     {
-      "ksi_id": "KSI-TPR-03",
+      "ksi_id": "KSI-SCR-MIT",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently identify, review, and mitigate potential supply chain risks. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -6023,10 +6517,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-16T21:54:01.560576+00:00",
       "remediation_commit": "a02eb7dfed1636cecb2e8acee82c62fd40b75e35",
-      "duration_hours": 24.37
+      "duration_hours": 24.37,
+      "legacy_ksi_id": "KSI-TPR-03"
     },
     {
-      "ksi_id": "KSI-INR-03",
+      "ksi_id": "KSI-INR-AAR",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Generate incident after action reports and persistently incorporate lessons learned. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: Required operational metric(s) not measured this run: incident_metrics No findings produced for this KSI.",
@@ -6036,10 +6531,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-17T03:19:44.282544+00:00",
       "remediation_commit": "d71b5d2378113234e3deee0135e29ad6b18d0f28",
-      "duration_hours": 29.79
+      "duration_hours": 29.79,
+      "legacy_ksi_id": "KSI-INR-03"
     },
     {
-      "ksi_id": "KSI-INR-03",
+      "ksi_id": "KSI-INR-AAR",
       "failed_at": "2026-06-17T06:13:19.883844+00:00",
       "failed_commit": "09c29adab5cd589db1fe1dc251b343c507224e51",
       "reason": "Insufficient (0%): Generate incident after action reports and persistently incorporate lessons learned. | 0/2 resources compliant, 1 unverified. | Failures: MTTR 1024.5h > target 72h (84/100 resolved). | Verdict: No verified evidence: 1 unverified, 1 accepted finding(s) \u2014 cannot assert compliance.",
@@ -6049,10 +6545,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-17T21:15:27.596550+00:00",
       "remediation_commit": "6bee2f52b8eb02b38d5603d623c0efb7b194b949",
-      "duration_hours": 15.04
+      "duration_hours": 15.04,
+      "legacy_ksi_id": "KSI-INR-03"
     },
     {
-      "ksi_id": "KSI-AFR-04",
+      "ksi_id": "FRR-VDR",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Insufficient (33%): Document the vulnerability detection and response methodology. | 1/3 resources compliant. | Verified: Vulnerability report '[resource]' exists, size: 8 KB, freshness: current (0d), versioned. | Failures: Governance document '[resource]' exists in CodeCommit but is EMPTY (0 bytes). | Warnings: Vulnerability report '[resource]' exists, size: 3.7 MB, freshness: aging (126d), versioned. Outcome concerns: last updated 126 days ago (threshold: 90 days for vulnerability). | Verdict: Score 33% below threshold 80% (1 pass / 1 fail / 1 warning / 0 unverified).",
@@ -6062,10 +6559,11 @@
       "score_at_failure": 33,
       "remediated_at": "2026-06-18T05:50:14.443286+00:00",
       "remediation_commit": "7f6de0c0ca3f59b1c933d249a002e5a37c2ee0dd",
-      "duration_hours": 56.3
+      "duration_hours": 56.3,
+      "legacy_ksi_id": "KSI-AFR-04"
     },
     {
-      "ksi_id": "KSI-AFR-05",
+      "ksi_id": "FRR-SCN",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Insufficient (0%): Verify SCN procedures are documented and active change tracking is maintained. | 0/3 resources compliant, 1 unverified. | Failures: Change notification artifact: empty S3 listing for prefix '[resource]' \u2014 required artifact is absent (zero objects matched). Existence is not evidenced.; 3PAO audit report: empty S3 listing for prefix '[resource]' \u2014 required artifact is absent (zero objects matched). Existence is not evidenced. | Verdict: Score 0% below threshold 80% (0 pass / 2 fail / 0 warning / 1 unverified).",
@@ -6075,10 +6573,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-18T05:50:14.443286+00:00",
       "remediation_commit": "7f6de0c0ca3f59b1c933d249a002e5a37c2ee0dd",
-      "duration_hours": 56.3
+      "duration_hours": 56.3,
+      "legacy_ksi_id": "KSI-AFR-05"
     },
     {
-      "ksi_id": "KSI-CNA-01",
+      "ksi_id": "KSI-CNA-RNT",
       "failed_at": "2026-05-11T23:48:15.169562+00:00",
       "failed_commit": "347dea29ffb2add235bcde25a55de977f4c0ecaf",
       "reason": "Insufficient (0%): Persistently ensure all machine-based information resources are configured to limit inbound and outbound network traf... | 6/9 resources compliant. CRITICAL OVERRIDE: Open ingress (0.0.0.0/0) on EC2; All Traffic protocol open to internet. | Verified: SG '[resource]' properly limits traffic \u2014 no world exposure, no broad CIDRs.; SG '[resource]' properly limits traffic \u2014 no world exposure, no broad CIDRs.; SG '[resource]' properly limits traffic \u2014 no world exposure, no broad CIDRs. |   ...and 2 more verification(s) | Failures:  CRITICAL: Critical findings detected: Open ingress (0.0.0.0/0) on EC2; All Traffic protocol open to internet | Warnings: SG '[resource]' uses broad internal CIDRs ([internal-cidr] ([protocol-ports])). FedRAMP best practice: tighten ranges or use [security-group] references.; Exposure: SG '[resource]' allows TCP 443-443 from a public CIDR (IPv4); review against intended traffic scope.",
@@ -6088,10 +6587,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-18T19:44:58.478211+00:00",
       "remediation_commit": "d0c92cdbe352ebf29efd1079a20c54dd9e8a6bcf",
-      "duration_hours": 907.95
+      "duration_hours": 907.95,
+      "legacy_ksi_id": "KSI-CNA-01"
     },
     {
-      "ksi_id": "KSI-IAM-07",
+      "ksi_id": "KSI-IAM-AAM",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Securely manage the lifecycle and privileges of all accounts, roles, and groups, using automation. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -6101,10 +6601,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-18T19:44:58.478211+00:00",
       "remediation_commit": "d0c92cdbe352ebf29efd1079a20c54dd9e8a6bcf",
-      "duration_hours": 70.21
+      "duration_hours": 70.21,
+      "legacy_ksi_id": "KSI-IAM-07"
     },
     {
-      "ksi_id": "KSI-PIY-01",
+      "ksi_id": "KSI-PIY-GIV",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Use authoritative sources to automatically generate real-time inventories of all information resources when needed. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: Required operational metric(s) not measured this run: inventory_metrics No findings produced for this KSI.",
@@ -6114,10 +6615,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-18T19:44:58.478211+00:00",
       "remediation_commit": "d0c92cdbe352ebf29efd1079a20c54dd9e8a6bcf",
-      "duration_hours": 70.21
+      "duration_hours": 70.21,
+      "legacy_ksi_id": "KSI-PIY-01"
     },
     {
-      "ksi_id": "KSI-MLA-05",
+      "ksi_id": "KSI-MLA-EVC",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently evaluate and test the configuration of machine-based information resources, especially infrastructure as... | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -6127,10 +6629,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-18T22:00:17.572603+00:00",
       "remediation_commit": "25cf5b7dc34cd79018ed53e0fec070c8ff5397e5",
-      "duration_hours": 72.47
+      "duration_hours": 72.47,
+      "legacy_ksi_id": "KSI-MLA-05"
     },
     {
-      "ksi_id": "KSI-INR-03",
+      "ksi_id": "KSI-INR-AAR",
       "failed_at": "2026-06-17T23:35:24.261230+00:00",
       "failed_commit": "57b72826f30f7499812fe7515a313b786183e14a",
       "reason": "Insufficient (0%): Generate incident after action reports and persistently incorporate lessons learned. | 0/2 resources compliant, 1 unverified. | Failures: MTTR 1023.6h > target 72h (77/100 resolved). | Verdict: No verified evidence: 1 unverified, 1 accepted finding(s) \u2014 cannot assert compliance.",
@@ -6140,10 +6643,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-19T06:53:42.949670+00:00",
       "remediation_commit": "a3f220972ac59c7d50a10edbbeeaa200b60bfeba",
-      "duration_hours": 31.31
+      "duration_hours": 31.31,
+      "legacy_ksi_id": "KSI-INR-03"
     },
     {
-      "ksi_id": "KSI-MLA-08",
+      "ksi_id": "KSI-MLA-ALA",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Use a least-privileged, role and attribute-based, and just-in-time access authorization model for access to log data. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -6153,10 +6657,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-19T06:53:42.949670+00:00",
       "remediation_commit": "a3f220972ac59c7d50a10edbbeeaa200b60bfeba",
-      "duration_hours": 81.36
+      "duration_hours": 81.36,
+      "legacy_ksi_id": "KSI-MLA-08"
     },
     {
-      "ksi_id": "KSI-SVC-04",
+      "ksi_id": "KSI-SVC-ACM",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Manage configuration of machine-based information resources using automation. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: Required operational metric(s) not measured this run: patch_metrics No findings produced for this KSI.",
@@ -6166,10 +6671,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-19T06:53:42.949670+00:00",
       "remediation_commit": "a3f220972ac59c7d50a10edbbeeaa200b60bfeba",
-      "duration_hours": 81.36
+      "duration_hours": 81.36,
+      "legacy_ksi_id": "KSI-SVC-04"
     },
     {
-      "ksi_id": "KSI-PIY-08",
+      "ksi_id": "KSI-PIY-RES",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently review executive support for achieving the organizations security objectives. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -6179,10 +6685,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-19T08:18:31.058567+00:00",
       "remediation_commit": "f57286e0e477ccd8b75b1c707a9b57dcd0308807",
-      "duration_hours": 82.77
+      "duration_hours": 82.77,
+      "legacy_ksi_id": "KSI-PIY-08"
     },
     {
-      "ksi_id": "KSI-SVC-10",
+      "ksi_id": "KSI-SVC-RUD",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Remove unwanted federal customer data promptly when requested by an agency in alignment with customer agreements, inc... | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -6192,10 +6699,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-19T08:18:31.058567+00:00",
       "remediation_commit": "f57286e0e477ccd8b75b1c707a9b57dcd0308807",
-      "duration_hours": 82.77
+      "duration_hours": 82.77,
+      "legacy_ksi_id": "KSI-SVC-10"
     },
     {
-      "ksi_id": "KSI-IAM-06",
+      "ksi_id": "KSI-IAM-SUS",
       "failed_at": "2026-06-19T06:53:42.949670+00:00",
       "failed_commit": "a3f220972ac59c7d50a10edbbeeaa200b60bfeba",
       "reason": "Insufficient (33%): Automatically disable or otherwise secure accounts with privileged access in response to suspicious activity | 1/3 resources compliant, 2 unverified. | Verified: Verified: Governance document '[resource]' is substantive (4902 bytes, 13 sections). | Verdict: Score 33% below threshold 100%.",
@@ -6205,10 +6713,11 @@
       "score_at_failure": 33,
       "remediated_at": "2026-06-19T10:52:08.518481+00:00",
       "remediation_commit": "f8ec8c2a8fe2b75c3d1ad7734f06848e66fa57e2",
-      "duration_hours": 3.97
+      "duration_hours": 3.97,
+      "legacy_ksi_id": "KSI-IAM-06"
     },
     {
-      "ksi_id": "KSI-SVC-06",
+      "ksi_id": "KSI-SVC-ASM",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Automate management, protection, and regular rotation of digital keys, certificates, and other secrets. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: Required operational metric(s) not measured this run: kms_rotation_metrics, cert_expiry_metrics, secret_rotation_metrics No findings produced for this KSI.",
@@ -6218,10 +6727,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-19T19:38:39.037526+00:00",
       "remediation_commit": "3ee30ca6a8f921a03ceeb6e48621d4ea65aa72af",
-      "duration_hours": 94.11
+      "duration_hours": 94.11,
+      "legacy_ksi_id": "KSI-SVC-06"
     },
     {
-      "ksi_id": "KSI-IAM-07",
+      "ksi_id": "KSI-IAM-AAM",
       "failed_at": "2026-06-21T06:10:10.833641+00:00",
       "failed_commit": "7c644502d8699964068dbf1bd5ccbe27f8306d6d",
       "reason": "Insufficient (0%): Securely manage the lifecycle and privileges of all accounts, roles, and groups, using automation. | 0/2 resources compliant, 2 unverified. | Verdict: No verified evidence: 2 unverified, 0 accepted finding(s) \u2014 cannot assert compliance.",
@@ -6231,10 +6741,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-21T09:48:30.482003+00:00",
       "remediation_commit": "541de9ec450fdc84764b5f1bd3aad5aa79fe7b40",
-      "duration_hours": 3.64
+      "duration_hours": 3.64,
+      "legacy_ksi_id": "KSI-IAM-07"
     },
     {
-      "ksi_id": "KSI-CMT-02",
+      "ksi_id": "KSI-CMT-RMV",
       "failed_at": "2026-05-12T03:06:48.256462+00:00",
       "failed_commit": "5fe128e1ff844263ab7f67b57fac4c969bf08226",
       "reason": "Insufficient (55%): Execute changes to machine-based information resources through redeployment of version controlled immutable resources... | 5/11 resources compliant, 2 unverified. | Verified: IMDSv2 Enforced: Instance '[resource]' requires HttpTokens.; IMDSv2 Enforced: Instance '[resource]' requires HttpTokens.; IMDSv2 Enforced: Instance '[resource]' requires HttpTokens. |   ...and 2 more verification(s) | Failures: Risk: Instance '[resource]' allows IMDSv1 (Legacy Metadata). Enforce v2.; Risk: Instance '[resource]' allows IMDSv1 (Legacy Metadata). Enforce v2.; Risk: Instance '[resource]' allows IMDSv1 (Legacy Metadata). Enforce v2. | Warnings: Pipeline success rate 0% below 95% target (0/50).",
@@ -6244,10 +6755,11 @@
       "score_at_failure": 55,
       "remediated_at": "2026-06-24T17:18:21.384229+00:00",
       "remediation_commit": "6ecf916de886e9acd09c916017bd3ca1da27bb72",
-      "duration_hours": 1046.19
+      "duration_hours": 1046.19,
+      "legacy_ksi_id": "KSI-CMT-02"
     },
     {
-      "ksi_id": "KSI-CNA-06",
+      "ksi_id": "KSI-CNA-OFA",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Appropriately optimize machine-based information resources for high availability and rapid recovery. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -6257,10 +6769,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-24T17:18:21.384229+00:00",
       "remediation_commit": "6ecf916de886e9acd09c916017bd3ca1da27bb72",
-      "duration_hours": 211.77
+      "duration_hours": 211.77,
+      "legacy_ksi_id": "KSI-CNA-06"
     },
     {
-      "ksi_id": "KSI-MLA-01",
+      "ksi_id": "KSI-MLA-OSM",
       "failed_at": "2026-06-24T17:18:21.384229+00:00",
       "failed_commit": "6ecf916de886e9acd09c916017bd3ca1da27bb72",
       "reason": "Insufficient (75%): Log all activity on all information resources supporting the cloud service offering to a protected audit log. | 3/5 resources compliant, 1 unverified. | Verified: Trail is Secure (Multi-Region, Validated, KMS-Encrypted, Global Events) [organization trail; CloudWatch Logs integrated \u2192 arn:aws:[redacted]; delivery role arn:aws:[redacted]; Trail logging rate 100% (1/1 trails actively logging).; S3 access-logging rate 100% (11 buckets covered). | Failures: ALB access-log rate 50% < target 100% (1/2 ALBs without S3 access logs). | Verdict: Operational metric(s) below target: alb_access_log_metrics",
@@ -6270,10 +6783,11 @@
       "score_at_failure": 75,
       "remediated_at": "2026-06-29T21:08:54.671378+00:00",
       "remediation_commit": "3699ef41f8e6895044bf91ebec972e5c007fb070",
-      "duration_hours": 123.84
+      "duration_hours": 123.84,
+      "legacy_ksi_id": "KSI-MLA-01"
     },
     {
-      "ksi_id": "KSI-IAM-07",
+      "ksi_id": "KSI-IAM-AAM",
       "failed_at": "2026-06-25T21:12:30.002458+00:00",
       "failed_commit": "5506da106fff47abac933dce01231ff72ddf2cae",
       "reason": "Insufficient (0%): Securely manage the lifecycle and privileges of all accounts, roles, and groups, using automation. | 0/2 resources compliant, 1 unverified. | Failures: IAM credential report (3 users): 1 console user(s) without MFA | Verdict: Score 0% below threshold 100% (0 pass / 1 fail / 0 warning / 1 unverified).",
@@ -6283,10 +6797,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-06-30T19:20:35.145884+00:00",
       "remediation_commit": "c13312618ae29a5933c5d81320618323f41fe400",
-      "duration_hours": 118.13
+      "duration_hours": 118.13,
+      "legacy_ksi_id": "KSI-IAM-07"
     },
     {
-      "ksi_id": "KSI-MLA-02",
+      "ksi_id": "KSI-MLA-RVL",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Persistently review and audit logs. | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: No findings produced for this KSI.",
@@ -6296,10 +6811,11 @@
       "score_at_failure": 0,
       "remediated_at": "2026-07-01T03:32:42.801767+00:00",
       "remediation_commit": "9016eaf6dd9aaf3a98c5399b6af6bd4262f8ec08",
-      "duration_hours": 366.01
+      "duration_hours": 366.01,
+      "legacy_ksi_id": "KSI-MLA-02"
     },
     {
-      "ksi_id": "KSI-AFR-01",
+      "ksi_id": "FRR-MAS",
       "failed_at": "2026-06-17T23:35:24.261230+00:00",
       "failed_commit": "57b72826f30f7499812fe7515a313b786183e14a",
       "reason": "Insufficient (2%): Validates the complete FedRAMP Minimum Assessment Scope (MAS) covering machine resources, human resources, and proces... | 1/38 resources compliant, 1 unverified. | Verified: Verified: Governance document '[resource]' contains 46 structured entries (8348 bytes). | Warnings: Asset Active but inventory-governance gap: missing required tags ['[resource]', '[resource]']. Tag for ownership/environment to evidence a governed inventory (AFR-01/CNA-07).; Asset Active but inventory-governance gap: missing required tags ['[resource]', '[resource]']. Tag for ownership/environment to evidence a governed inventory (AFR-01/CNA-07). |   ...and 34 more warning(s) | Verdict: Score 2% below threshold 80% (1 pass / 0 fail / 36 warning / 1 unverified).",
@@ -6309,10 +6825,11 @@
       "score_at_failure": 2,
       "remediated_at": "2026-07-01T14:31:09.508721+00:00",
       "remediation_commit": "04cfa6f7f55f35ee9114a0d4106844f253be02df",
-      "duration_hours": 326.93
+      "duration_hours": 326.93,
+      "legacy_ksi_id": "KSI-AFR-01"
     },
     {
-      "ksi_id": "KSI-CNA-07",
+      "ksi_id": "KSI-CNA-IBP",
       "failed_at": "2026-06-17T23:35:24.261230+00:00",
       "failed_commit": "57b72826f30f7499812fe7515a313b786183e14a",
       "reason": "Insufficient (0%): Persistently ensure cloud-native machine-based information resources are implemented based on the host providers best... | 0/38 resources compliant. | Warnings: Asset Active but inventory-governance gap: missing required tags ['[resource]', '[resource]']. Tag for ownership/environment to evidence a governed inventory (AFR-01/CNA-07).; Asset Active but inventory-governance gap: missing required tags ['[resource]', '[resource]']. Tag for ownership/environment to evidence a governed inventory (AFR-01/CNA-07). |   ...and 36 more warning(s) | Verdict: Score 0% below threshold 100% (0 pass / 0 fail / 38 warning / 0 unverified).",
@@ -6322,7 +6839,8 @@
       "score_at_failure": 0,
       "remediated_at": "2026-07-01T14:31:09.508721+00:00",
       "remediation_commit": "04cfa6f7f55f35ee9114a0d4106844f253be02df",
-      "duration_hours": 326.93
+      "duration_hours": 326.93,
+      "legacy_ksi_id": "KSI-CNA-07"
     },
     {
       "ksi_id": "KSI-SCR-MON",
@@ -6339,635 +6857,715 @@
     }
   ],
   "ksi_stats": {
-    "KSI-CED-01": {
-      "total_failures": 6,
-      "total_remediations": 6,
-      "mttr_hours": 18.66,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 62.87,
-      "shortest_outage_hours": 1.12
-    },
-    "KSI-CMT-02": {
-      "total_failures": 8,
-      "total_remediations": 8,
-      "mttr_hours": 147.84,
-      "last_failure": "2026-05-12T03:06:48.256462+00:00",
-      "longest_outage_hours": 1046.19,
-      "shortest_outage_hours": 0.17
-    },
-    "KSI-CNA-05": {
-      "total_failures": 9,
-      "total_remediations": 8,
-      "mttr_hours": 42.53,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 165.24,
-      "shortest_outage_hours": 0.29
-    },
-    "KSI-IAM-04": {
-      "total_failures": 10,
-      "total_remediations": 10,
-      "mttr_hours": 13.81,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 62.87,
-      "shortest_outage_hours": 0.57
-    },
-    "KSI-IAM-06": {
-      "total_failures": 5,
-      "total_remediations": 5,
-      "mttr_hours": 35.72,
-      "last_failure": "2026-06-19T06:53:42.949670+00:00",
-      "longest_outage_hours": 62.87,
-      "shortest_outage_hours": 3.97
-    },
-    "KSI-INR-01": {
-      "total_failures": 8,
-      "total_remediations": 8,
-      "mttr_hours": 33.55,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 81.94,
-      "shortest_outage_hours": 1.56
-    },
-    "KSI-MLA-05": {
-      "total_failures": 8,
-      "total_remediations": 8,
-      "mttr_hours": 31.8,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 111.78,
-      "shortest_outage_hours": 0.57
-    },
-    "KSI-MLA-06": {
-      "total_failures": 5,
-      "total_remediations": 5,
-      "mttr_hours": 26.93,
-      "last_failure": "2025-06-05T23:49:48Z"
-    },
-    "KSI-PIY-01": {
-      "total_failures": 13,
-      "total_remediations": 13,
-      "mttr_hours": 16.51,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 70.21,
-      "shortest_outage_hours": 0.42
-    },
-    "KSI-PIY-03": {
-      "total_failures": 8,
-      "total_remediations": 8,
-      "mttr_hours": 136.29,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 508.02,
-      "shortest_outage_hours": 1.12
-    },
-    "KSI-PIY-05": {
-      "total_failures": 4,
-      "total_remediations": 4,
-      "mttr_hours": 52.88,
-      "last_failure": "2025-10-12T03:08:36.669011Z"
-    },
-    "KSI-PIY-07": {
-      "total_failures": 5,
-      "total_remediations": 5,
-      "mttr_hours": 43.88,
-      "last_failure": "2025-10-12T03:08:36.669011Z"
-    },
-    "KSI-RPL-02": {
-      "total_failures": 9,
-      "total_remediations": 9,
-      "mttr_hours": 36.43,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 184.59,
-      "shortest_outage_hours": 0.39
-    },
-    "KSI-SVC-04": {
-      "total_failures": 6,
-      "total_remediations": 6,
-      "mttr_hours": 62.31,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 141.38,
-      "shortest_outage_hours": 3.35
-    },
-    "KSI-SVC-06": {
-      "total_failures": 8,
-      "total_remediations": 8,
-      "mttr_hours": 49.16,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 156.9,
-      "shortest_outage_hours": 1.56
-    },
-    "KSI-TPR-01": {
-      "total_failures": 6,
-      "total_remediations": 6,
-      "mttr_hours": 28.96,
-      "last_failure": "2025-09-25T19:26:49.871705Z"
-    },
-    "KSI-INR-03": {
-      "total_failures": 12,
-      "total_remediations": 12,
-      "mttr_hours": 40.85,
-      "last_failure": "2026-06-17T23:35:24.261230+00:00",
-      "longest_outage_hours": 106.02,
-      "shortest_outage_hours": 0.32
-    },
-    "KSI-CMT-03": {
-      "total_failures": 11,
-      "total_remediations": 11,
-      "mttr_hours": 34.15,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 185.21,
-      "shortest_outage_hours": 0.57
-    },
-    "KSI-MLA-03": {
-      "total_failures": 3,
-      "total_remediations": 3,
-      "mttr_hours": 31.62,
-      "last_failure": "2025-06-05T05:01:53Z"
-    },
-    "KSI-SVC-01": {
-      "total_failures": 5,
-      "total_remediations": 5,
-      "mttr_hours": 24.19,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 81.05,
-      "shortest_outage_hours": 2.07
-    },
-    "KSI-SVC-05": {
-      "total_failures": 7,
-      "total_remediations": 7,
-      "mttr_hours": 38.76,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 163.64,
-      "shortest_outage_hours": 1.81
-    },
-    "KSI-CNA-02": {
-      "total_failures": 9,
-      "total_remediations": 8,
-      "mttr_hours": 27.38,
-      "last_failure": "2026-05-11T23:48:15.169562+00:00",
-      "longest_outage_hours": 185.46,
-      "shortest_outage_hours": 0.29
-    },
-    "KSI-SVC-07": {
-      "total_failures": 3,
-      "total_remediations": 3,
-      "mttr_hours": 28.03,
-      "last_failure": "2025-06-06T04:21:09.354677Z"
-    },
-    "KSI-CNA-01": {
-      "total_failures": 12,
-      "total_remediations": 12,
-      "mttr_hours": 132.65,
-      "last_failure": "2026-05-11T23:48:15.169562+00:00",
-      "longest_outage_hours": 907.95,
-      "shortest_outage_hours": 0.29
-    },
-    "KSI-IAM-01": {
-      "total_failures": 11,
-      "total_remediations": 10,
-      "mttr_hours": 25.2,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 146.8,
-      "shortest_outage_hours": 0.57
-    },
-    "KSI-CMT-01": {
-      "total_failures": 11,
-      "total_remediations": 11,
-      "mttr_hours": 24.64,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 168.91,
-      "shortest_outage_hours": 0.57
-    },
-    "KSI-MLA-02": {
-      "total_failures": 7,
-      "total_remediations": 7,
-      "mttr_hours": 65.3,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 366.01,
-      "shortest_outage_hours": 1.53
-    },
-    "KSI-CNA-07": {
-      "total_failures": 9,
-      "total_remediations": 9,
-      "mttr_hours": 70.98,
-      "last_failure": "2026-06-17T23:35:24.261230+00:00",
-      "longest_outage_hours": 326.93,
-      "shortest_outage_hours": 1.12
-    },
-    "KSI-PIY-06": {
-      "total_failures": 5,
-      "total_remediations": 5,
-      "mttr_hours": 34.89,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 124.73,
-      "shortest_outage_hours": 1.12
-    },
-    "KSI-RPL-01": {
-      "total_failures": 20,
-      "total_remediations": 20,
-      "mttr_hours": 13.11,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 184.59,
-      "shortest_outage_hours": 0.29
-    },
-    "KSI-CMT-04": {
-      "total_failures": 5,
-      "total_remediations": 5,
-      "mttr_hours": 133.28,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 302.57,
-      "shortest_outage_hours": 1.12
-    },
-    "KSI-TPR-04": {
-      "total_failures": 13,
-      "total_remediations": 12,
-      "mttr_hours": 10.74,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00"
-    },
-    "KSI-INR-02": {
-      "total_failures": 17,
-      "total_remediations": 17,
-      "mttr_hours": 8.79,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 48.93,
-      "shortest_outage_hours": 0.29
-    },
-    "KSI-RPL-04": {
-      "total_failures": 17,
-      "total_remediations": 17,
-      "mttr_hours": 16.44,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 178.22,
-      "shortest_outage_hours": 0.19
-    },
-    "KSI-PIY-02": {
-      "total_failures": 8,
-      "total_remediations": 8,
-      "mttr_hours": 24.43,
-      "last_failure": "2025-12-22T03:23:53.810599Z"
-    },
-    "KSI-CNA-06": {
-      "total_failures": 8,
-      "total_remediations": 8,
-      "mttr_hours": 52.17,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 211.77,
-      "shortest_outage_hours": 0.29
-    },
-    "KSI-PIY-04": {
-      "total_failures": 6,
-      "total_remediations": 6,
-      "mttr_hours": 38.23,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 160.54,
-      "shortest_outage_hours": 1.12
-    },
-    "KSI-CNA-04": {
-      "total_failures": 13,
-      "total_remediations": 12,
-      "mttr_hours": 18.63,
-      "last_failure": "2026-05-11T23:48:15.169562+00:00",
-      "longest_outage_hours": 81.05,
-      "shortest_outage_hours": 0.19
-    },
-    "KSI-CED-02": {
-      "total_failures": 3,
-      "total_remediations": 3,
-      "mttr_hours": 29.36,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 85.44,
-      "shortest_outage_hours": 1.12
-    },
-    "KSI-SVC-03": {
-      "total_failures": 6,
-      "total_remediations": 6,
-      "mttr_hours": 6.39,
-      "last_failure": "2025-06-06T03:48:06.017208Z"
-    },
-    "KSI-TPR-02": {
-      "total_failures": 4,
-      "total_remediations": 4,
-      "mttr_hours": 16.86,
-      "last_failure": "2025-06-10T18:51:13.351595Z"
-    },
-    "KSI-MLA-04": {
-      "total_failures": 4,
-      "total_remediations": 4,
-      "mttr_hours": 22.8,
-      "last_failure": "2025-06-06T04:21:09.354677Z"
-    },
-    "KSI-TPR-03": {
-      "total_failures": 8,
-      "total_remediations": 8,
-      "mttr_hours": 33.36,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 136.95,
-      "shortest_outage_hours": 0.57
-    },
-    "KSI-SVC-02": {
-      "total_failures": 4,
-      "total_remediations": 4,
-      "mttr_hours": 29.68,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 111.04,
-      "shortest_outage_hours": 1.12
-    },
-    "KSI-IAM-05": {
-      "total_failures": 8,
-      "total_remediations": 8,
-      "mttr_hours": 17.5,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 76.76,
-      "shortest_outage_hours": 0.29
-    },
-    "KSI-CNA-03": {
-      "total_failures": 7,
-      "total_remediations": 7,
-      "mttr_hours": 33.21,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 185.46,
-      "shortest_outage_hours": 0.29
-    },
-    "KSI-IAM-02": {
-      "total_failures": 9,
-      "total_remediations": 9,
-      "mttr_hours": 3.7,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 11.56,
-      "shortest_outage_hours": 0.25
-    },
-    "KSI-CMT-05": {
-      "total_failures": 5,
-      "total_remediations": 5,
-      "mttr_hours": 77.46,
-      "last_failure": "2025-10-14T18:40:19.682172Z"
-    },
-    "KSI-RPL-03": {
-      "total_failures": 19,
-      "total_remediations": 19,
-      "mttr_hours": 14.12,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 178.22,
-      "shortest_outage_hours": 0.29
-    },
-    "KSI-IAM-03": {
-      "total_failures": 9,
-      "total_remediations": 8,
-      "mttr_hours": 13.6,
-      "last_failure": "2026-06-24T03:18:27.372697+00:00",
-      "longest_outage_hours": 47.67,
-      "shortest_outage_hours": 0.29
-    },
-    "KSI-MLA-01": {
-      "total_failures": 13,
-      "total_remediations": 12,
-      "mttr_hours": 35.75,
-      "last_failure": "2026-07-03T17:05:51.763902+00:00",
-      "longest_outage_hours": 186.68,
-      "shortest_outage_hours": 0.29
-    },
     "terraform": {
       "total_failures": 1,
       "total_remediations": 0,
       "mttr_hours": null,
       "last_failure": "2025-06-06T03:48:06.017208Z"
     },
-    "KSI-CED-03": {
+    "KSI-CNA-DFP": {
+      "total_failures": 14,
+      "total_remediations": 0,
+      "mttr_hours": 18.63,
+      "last_failure": "2026-07-06T17:51:14.723954+00:00",
+      "longest_outage_hours": 81.05,
+      "shortest_outage_hours": 0.19,
+      "legacy_ksi_id": [
+        "KSI-CNA-04"
+      ]
+    },
+    "KSI-CNA-MAT": {
+      "total_failures": 10,
+      "total_remediations": 0,
+      "mttr_hours": 27.38,
+      "last_failure": "2026-07-06T17:51:14.723954+00:00",
+      "longest_outage_hours": 185.46,
+      "shortest_outage_hours": 0.29,
+      "legacy_ksi_id": [
+        "KSI-CNA-02"
+      ]
+    },
+    "KSI-CNA-RVP": {
+      "total_failures": 10,
+      "total_remediations": 0,
+      "mttr_hours": 42.53,
+      "last_failure": "2026-07-06T17:51:14.723954+00:00",
+      "longest_outage_hours": 165.24,
+      "shortest_outage_hours": 0.29,
+      "legacy_ksi_id": [
+        "KSI-CNA-05"
+      ]
+    },
+    "KSI-IAM-APM": {
+      "total_failures": 21,
+      "total_remediations": 0,
+      "mttr_hours": 25.2,
+      "last_failure": "2026-07-06T17:51:14.723954+00:00",
+      "longest_outage_hours": 146.8,
+      "shortest_outage_hours": 0.57,
+      "legacy_ksi_id": [
+        "KSI-IAM-01"
+      ]
+    },
+    "KSI-IAM-SNU": {
+      "total_failures": 10,
+      "total_remediations": 0,
+      "mttr_hours": 13.6,
+      "last_failure": "2026-07-06T17:51:14.723954+00:00",
+      "longest_outage_hours": 47.67,
+      "shortest_outage_hours": 0.29,
+      "legacy_ksi_id": [
+        "KSI-IAM-03"
+      ]
+    },
+    "KSI-MLA-OSM": {
+      "total_failures": 14,
+      "total_remediations": 0,
+      "mttr_hours": 35.75,
+      "last_failure": "2026-07-06T17:51:14.723954+00:00",
+      "longest_outage_hours": 186.68,
+      "shortest_outage_hours": 0.29,
+      "legacy_ksi_id": [
+        "KSI-MLA-01"
+      ]
+    },
+    "KSI-SCR-MON": {
+      "total_failures": 14,
+      "total_remediations": 1,
+      "mttr_hours": 51.17,
+      "last_failure": "2026-07-06T17:51:14.723954+00:00",
+      "longest_outage_hours": 51.17,
+      "shortest_outage_hours": 51.17,
+      "legacy_ksi_id": [
+        "KSI-TPR-04"
+      ]
+    },
+    "KSI-CMT-RMV": {
+      "total_failures": 9,
+      "total_remediations": 0,
+      "mttr_hours": 147.84,
+      "last_failure": "2026-07-07T21:07:19.254229+00:00",
+      "longest_outage_hours": 1046.19,
+      "shortest_outage_hours": 0.17,
+      "legacy_ksi_id": [
+        "KSI-CMT-02"
+      ]
+    },
+    "KSI-CNA-IBP": {
+      "total_failures": 10,
+      "total_remediations": 0,
+      "mttr_hours": 70.98,
+      "last_failure": "2026-07-07T21:07:19.254229+00:00",
+      "longest_outage_hours": 326.93,
+      "shortest_outage_hours": 1.12,
+      "legacy_ksi_id": [
+        "KSI-CNA-07"
+      ]
+    },
+    "KSI-CED-RAT": {
+      "total_failures": 22,
+      "total_remediations": 6,
+      "mttr_hours": 18.66,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 62.87,
+      "shortest_outage_hours": 1.12,
+      "legacy_ksi_id": [
+        "KSI-CED-01"
+      ]
+    },
+    "KSI-IAM-JIT": {
+      "total_failures": 10,
+      "total_remediations": 10,
+      "mttr_hours": 13.81,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 62.87,
+      "shortest_outage_hours": 0.57,
+      "legacy_ksi_id": [
+        "KSI-IAM-04"
+      ]
+    },
+    "KSI-IAM-SUS": {
+      "total_failures": 5,
+      "total_remediations": 5,
+      "mttr_hours": 35.72,
+      "last_failure": "2026-06-19T06:53:42.949670+00:00",
+      "longest_outage_hours": 62.87,
+      "shortest_outage_hours": 3.97,
+      "legacy_ksi_id": [
+        "KSI-IAM-06"
+      ]
+    },
+    "KSI-INR-RIR": {
+      "total_failures": 8,
+      "total_remediations": 8,
+      "mttr_hours": 33.55,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 81.94,
+      "shortest_outage_hours": 1.56,
+      "legacy_ksi_id": [
+        "KSI-INR-01"
+      ]
+    },
+    "KSI-MLA-EVC": {
+      "total_failures": 8,
+      "total_remediations": 8,
+      "mttr_hours": 31.8,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 111.78,
+      "shortest_outage_hours": 0.57,
+      "legacy_ksi_id": [
+        "KSI-MLA-05"
+      ]
+    },
+    "KSI-PIY-GIV": {
+      "total_failures": 13,
+      "total_remediations": 13,
+      "mttr_hours": 16.51,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 70.21,
+      "shortest_outage_hours": 0.42,
+      "legacy_ksi_id": [
+        "KSI-PIY-01"
+      ]
+    },
+    "KSI-PIY-RVD": {
+      "total_failures": 8,
+      "total_remediations": 8,
+      "mttr_hours": 136.29,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 508.02,
+      "shortest_outage_hours": 1.12,
+      "legacy_ksi_id": [
+        "KSI-PIY-03"
+      ]
+    },
+    "KSI-RPL-ARP": {
+      "total_failures": 9,
+      "total_remediations": 9,
+      "mttr_hours": 36.43,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 184.59,
+      "shortest_outage_hours": 0.39,
+      "legacy_ksi_id": [
+        "KSI-RPL-02"
+      ]
+    },
+    "KSI-SVC-ACM": {
+      "total_failures": 6,
+      "total_remediations": 6,
+      "mttr_hours": 62.31,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 141.38,
+      "shortest_outage_hours": 3.35,
+      "legacy_ksi_id": [
+        "KSI-SVC-04"
+      ]
+    },
+    "KSI-SVC-ASM": {
+      "total_failures": 8,
+      "total_remediations": 8,
+      "mttr_hours": 49.16,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 156.9,
+      "shortest_outage_hours": 1.56,
+      "legacy_ksi_id": [
+        "KSI-SVC-06"
+      ]
+    },
+    "KSI-INR-AAR": {
+      "total_failures": 12,
+      "total_remediations": 12,
+      "mttr_hours": 40.85,
+      "last_failure": "2026-06-17T23:35:24.261230+00:00",
+      "longest_outage_hours": 106.02,
+      "shortest_outage_hours": 0.32,
+      "legacy_ksi_id": [
+        "KSI-INR-03"
+      ]
+    },
+    "KSI-CMT-VTD": {
       "total_failures": 11,
       "total_remediations": 11,
-      "mttr_hours": 75.73,
+      "mttr_hours": 34.15,
       "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 789.0,
-      "shortest_outage_hours": 0.19
+      "longest_outage_hours": 185.21,
+      "shortest_outage_hours": 0.57,
+      "legacy_ksi_id": [
+        "KSI-CMT-03"
+      ]
     },
-    "KSI-IAM-07": {
+    "KSI-SVC-EIS": {
+      "total_failures": 5,
+      "total_remediations": 5,
+      "mttr_hours": 24.19,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 81.05,
+      "shortest_outage_hours": 2.07,
+      "legacy_ksi_id": [
+        "KSI-SVC-01"
+      ]
+    },
+    "KSI-SVC-VRI": {
+      "total_failures": 7,
+      "total_remediations": 7,
+      "mttr_hours": 38.76,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 163.64,
+      "shortest_outage_hours": 1.81,
+      "legacy_ksi_id": [
+        "KSI-SVC-05"
+      ]
+    },
+    "KSI-CNA-RNT": {
+      "total_failures": 12,
+      "total_remediations": 12,
+      "mttr_hours": 132.65,
+      "last_failure": "2026-05-11T23:48:15.169562+00:00",
+      "longest_outage_hours": 907.95,
+      "shortest_outage_hours": 0.29,
+      "legacy_ksi_id": [
+        "KSI-CNA-01"
+      ]
+    },
+    "KSI-CMT-LMC": {
+      "total_failures": 11,
+      "total_remediations": 11,
+      "mttr_hours": 24.64,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 168.91,
+      "shortest_outage_hours": 0.57,
+      "legacy_ksi_id": [
+        "KSI-CMT-01"
+      ]
+    },
+    "KSI-MLA-RVL": {
+      "total_failures": 7,
+      "total_remediations": 7,
+      "mttr_hours": 65.3,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 366.01,
+      "shortest_outage_hours": 1.53,
+      "legacy_ksi_id": [
+        "KSI-MLA-02"
+      ]
+    },
+    "KSI-PIY-RIS": {
+      "total_failures": 5,
+      "total_remediations": 5,
+      "mttr_hours": 34.89,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 124.73,
+      "shortest_outage_hours": 1.12,
+      "legacy_ksi_id": [
+        "KSI-PIY-06"
+      ]
+    },
+    "KSI-RPL-RRO": {
+      "total_failures": 20,
+      "total_remediations": 20,
+      "mttr_hours": 13.11,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 184.59,
+      "shortest_outage_hours": 0.29,
+      "legacy_ksi_id": [
+        "KSI-RPL-01"
+      ]
+    },
+    "KSI-CMT-RVP": {
+      "total_failures": 5,
+      "total_remediations": 5,
+      "mttr_hours": 133.28,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 302.57,
+      "shortest_outage_hours": 1.12,
+      "legacy_ksi_id": [
+        "KSI-CMT-04"
+      ]
+    },
+    "KSI-INR-RPI": {
+      "total_failures": 17,
+      "total_remediations": 17,
+      "mttr_hours": 8.79,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 48.93,
+      "shortest_outage_hours": 0.29,
+      "legacy_ksi_id": [
+        "KSI-INR-02"
+      ]
+    },
+    "KSI-RPL-TRC": {
+      "total_failures": 17,
+      "total_remediations": 17,
+      "mttr_hours": 16.44,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 178.22,
+      "shortest_outage_hours": 0.19,
+      "legacy_ksi_id": [
+        "KSI-RPL-04"
+      ]
+    },
+    "KSI-CNA-OFA": {
+      "total_failures": 8,
+      "total_remediations": 8,
+      "mttr_hours": 52.17,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 211.77,
+      "shortest_outage_hours": 0.29,
+      "legacy_ksi_id": [
+        "KSI-CNA-06"
+      ]
+    },
+    "KSI-PIY-RSD": {
+      "total_failures": 6,
+      "total_remediations": 6,
+      "mttr_hours": 38.23,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 160.54,
+      "shortest_outage_hours": 1.12,
+      "legacy_ksi_id": [
+        "KSI-PIY-04"
+      ]
+    },
+    "KSI-SCR-MIT": {
+      "total_failures": 8,
+      "total_remediations": 8,
+      "mttr_hours": 33.36,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 136.95,
+      "shortest_outage_hours": 0.57,
+      "legacy_ksi_id": [
+        "KSI-TPR-03"
+      ]
+    },
+    "KSI-SVC-SIN": {
+      "total_failures": 4,
+      "total_remediations": 4,
+      "mttr_hours": 29.68,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 111.04,
+      "shortest_outage_hours": 1.12,
+      "legacy_ksi_id": [
+        "KSI-SVC-02"
+      ]
+    },
+    "KSI-IAM-ELP": {
+      "total_failures": 8,
+      "total_remediations": 8,
+      "mttr_hours": 17.5,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 76.76,
+      "shortest_outage_hours": 0.29,
+      "legacy_ksi_id": [
+        "KSI-IAM-05"
+      ]
+    },
+    "KSI-CNA-ULN": {
+      "total_failures": 7,
+      "total_remediations": 7,
+      "mttr_hours": 33.21,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 185.46,
+      "shortest_outage_hours": 0.29,
+      "legacy_ksi_id": [
+        "KSI-CNA-03"
+      ]
+    },
+    "KSI-RPL-ABO": {
+      "total_failures": 19,
+      "total_remediations": 19,
+      "mttr_hours": 14.12,
+      "last_failure": "2026-06-15T21:32:05.248293+00:00",
+      "longest_outage_hours": 178.22,
+      "shortest_outage_hours": 0.29,
+      "legacy_ksi_id": [
+        "KSI-RPL-03"
+      ]
+    },
+    "KSI-IAM-AAM": {
       "total_failures": 9,
       "total_remediations": 9,
       "mttr_hours": 22.65,
       "last_failure": "2026-06-25T21:12:30.002458+00:00",
       "longest_outage_hours": 118.13,
-      "shortest_outage_hours": 0.57
+      "shortest_outage_hours": 0.57,
+      "legacy_ksi_id": [
+        "KSI-IAM-07"
+      ]
     },
-    "KSI-SVC-09": {
+    "KSI-SVC-VCM": {
       "total_failures": 5,
       "total_remediations": 5,
       "mttr_hours": 7.05,
       "last_failure": "2026-06-15T21:32:05.248293+00:00",
       "longest_outage_hours": 24.37,
-      "shortest_outage_hours": 0.57
+      "shortest_outage_hours": 0.57,
+      "legacy_ksi_id": [
+        "KSI-SVC-09"
+      ]
     },
-    "KSI-MLA-07": {
+    "KSI-MLA-LET": {
       "total_failures": 6,
       "total_remediations": 6,
       "mttr_hours": 7.08,
       "last_failure": "2026-06-15T21:32:05.248293+00:00",
       "longest_outage_hours": 34.15,
-      "shortest_outage_hours": 0.57
+      "shortest_outage_hours": 0.57,
+      "legacy_ksi_id": [
+        "KSI-MLA-07"
+      ]
     },
-    "KSI-MLA-08": {
+    "KSI-MLA-ALA": {
       "total_failures": 6,
       "total_remediations": 6,
       "mttr_hours": 50.85,
       "last_failure": "2026-06-15T21:32:05.248293+00:00",
       "longest_outage_hours": 218.37,
-      "shortest_outage_hours": 0.57
+      "shortest_outage_hours": 0.57,
+      "legacy_ksi_id": [
+        "KSI-MLA-08"
+      ]
     },
-    "KSI-SVC-08": {
+    "KSI-SVC-PRR": {
       "total_failures": 4,
       "total_remediations": 4,
       "mttr_hours": 14.02,
       "last_failure": "2026-06-15T21:32:05.248293+00:00",
       "longest_outage_hours": 27.44,
-      "shortest_outage_hours": 0.57
+      "shortest_outage_hours": 0.57,
+      "legacy_ksi_id": [
+        "KSI-SVC-08"
+      ]
     },
-    "KSI-SVC-10": {
+    "KSI-SVC-RUD": {
       "total_failures": 5,
       "total_remediations": 5,
       "mttr_hours": 26.87,
       "last_failure": "2026-06-15T21:32:05.248293+00:00",
       "longest_outage_hours": 82.77,
-      "shortest_outage_hours": 0.57
+      "shortest_outage_hours": 0.57,
+      "legacy_ksi_id": [
+        "KSI-SVC-10"
+      ]
     },
-    "KSI-CNA-08": {
+    "KSI-CNA-EIS": {
       "total_failures": 3,
       "total_remediations": 3,
       "mttr_hours": 18.02,
       "last_failure": "2026-06-15T21:32:05.248293+00:00",
       "longest_outage_hours": 24.37,
-      "shortest_outage_hours": 6.03
+      "shortest_outage_hours": 6.03,
+      "legacy_ksi_id": [
+        "KSI-CNA-08"
+      ]
     },
-    "KSI-AFR-04": {
+    "FRR-VDR": {
       "total_failures": 2,
       "total_remediations": 2,
       "mttr_hours": 52.65,
       "last_failure": "2026-06-15T21:32:05.248293+00:00",
       "longest_outage_hours": 56.3,
-      "shortest_outage_hours": 49.0
+      "shortest_outage_hours": 49.0,
+      "legacy_ksi_id": [
+        "KSI-AFR-04"
+      ]
     },
-    "KSI-AFR-05": {
+    "FRR-SCN": {
       "total_failures": 2,
       "total_remediations": 2,
       "mttr_hours": 177.01,
       "last_failure": "2026-06-15T21:32:05.248293+00:00",
       "longest_outage_hours": 297.72,
-      "shortest_outage_hours": 56.3
+      "shortest_outage_hours": 56.3,
+      "legacy_ksi_id": [
+        "KSI-AFR-05"
+      ]
     },
-    "KSI-AFR-07": {
+    "FRR-SCG": {
       "total_failures": 3,
       "total_remediations": 3,
       "mttr_hours": 91.7,
       "last_failure": "2026-03-09T21:42:24.916581Z",
       "longest_outage_hours": 213.05,
-      "shortest_outage_hours": 28.91
+      "shortest_outage_hours": 28.91,
+      "legacy_ksi_id": [
+        "KSI-AFR-07"
+      ]
     },
-    "KSI-AFR-08": {
+    "FRR-AFC": {
       "total_failures": 4,
       "total_remediations": 4,
       "mttr_hours": 16.33,
       "last_failure": "2026-06-15T21:32:05.248293+00:00",
       "longest_outage_hours": 33.13,
-      "shortest_outage_hours": 1.12
+      "shortest_outage_hours": 1.12,
+      "legacy_ksi_id": [
+        "KSI-AFR-08"
+      ]
     },
-    "KSI-AFR-09": {
+    "FRR-SDR": {
       "total_failures": 2,
       "total_remediations": 2,
       "mttr_hours": 149.42,
       "last_failure": "2026-06-15T21:32:05.248293+00:00",
       "longest_outage_hours": 297.72,
-      "shortest_outage_hours": 1.12
+      "shortest_outage_hours": 1.12,
+      "legacy_ksi_id": [
+        "KSI-AFR-09"
+      ]
     },
-    "KSI-AFR-11": {
+    "FRR-CMU": {
       "total_failures": 5,
       "total_remediations": 5,
       "mttr_hours": 41.57,
       "last_failure": "2026-06-15T21:32:05.248293+00:00",
       "longest_outage_hours": 151.88,
-      "shortest_outage_hours": 1.12
+      "shortest_outage_hours": 1.12,
+      "legacy_ksi_id": [
+        "KSI-AFR-11"
+      ]
     },
-    "KSI-CED-04": {
-      "total_failures": 2,
-      "total_remediations": 2,
-      "mttr_hours": 372.87,
-      "last_failure": "2026-06-15T21:32:05.248293+00:00",
-      "longest_outage_hours": 744.62,
-      "shortest_outage_hours": 1.12
-    },
-    "KSI-PIY-08": {
+    "KSI-PIY-RES": {
       "total_failures": 2,
       "total_remediations": 2,
       "mttr_hours": 413.69,
       "last_failure": "2026-06-15T21:32:05.248293+00:00",
       "longest_outage_hours": 744.62,
-      "shortest_outage_hours": 82.77
+      "shortest_outage_hours": 82.77,
+      "legacy_ksi_id": [
+        "KSI-PIY-08"
+      ]
     },
-    "KSI-AFR-10": {
+    "FRR-IEC": {
       "total_failures": 3,
       "total_remediations": 3,
       "mttr_hours": 20.56,
       "last_failure": "2026-06-15T21:32:05.248293+00:00",
       "longest_outage_hours": 33.13,
-      "shortest_outage_hours": 1.12
+      "shortest_outage_hours": 1.12,
+      "legacy_ksi_id": [
+        "KSI-AFR-10"
+      ]
     },
-    "KSI-AFR-01": {
+    "FRR-MAS": {
       "total_failures": 4,
       "total_remediations": 4,
       "mttr_hours": 155.4,
       "last_failure": "2026-06-17T23:35:24.261230+00:00",
       "longest_outage_hours": 326.93,
-      "shortest_outage_hours": 1.15
+      "shortest_outage_hours": 1.15,
+      "legacy_ksi_id": [
+        "KSI-AFR-01"
+      ]
     },
-    "KSI-AFR-02": {
+    "FRR-FRC": {
       "total_failures": 1,
       "total_remediations": 1,
       "mttr_hours": 33.13,
       "last_failure": "2026-03-09T21:42:24.916581Z",
       "longest_outage_hours": 33.13,
-      "shortest_outage_hours": 33.13
+      "shortest_outage_hours": 33.13,
+      "legacy_ksi_id": [
+        "KSI-AFR-02"
+      ]
     },
-    "KSI-AFR-06": {
+    "FRR-CCM": {
       "total_failures": 2,
       "total_remediations": 2,
       "mttr_hours": 14.15,
       "last_failure": "2026-03-11T06:50:28.470258Z",
       "longest_outage_hours": 26.74,
-      "shortest_outage_hours": 1.56
+      "shortest_outage_hours": 1.56,
+      "legacy_ksi_id": [
+        "KSI-AFR-06"
+      ]
     },
-    "KSI-AFR-03": {
+    "FRR-CDS": {
       "total_failures": 1,
       "total_remediations": 1,
       "mttr_hours": 1.56,
       "last_failure": "2026-03-11T06:50:28.470258Z",
       "longest_outage_hours": 1.56,
-      "shortest_outage_hours": 1.56
+      "shortest_outage_hours": 1.56,
+      "legacy_ksi_id": [
+        "KSI-AFR-03"
+      ]
     },
-    "KSI-CNA-DFP": {
-      "total_failures": 1,
-      "total_remediations": 0,
-      "mttr_hours": null,
-      "last_failure": "2026-07-06T17:51:14.723954+00:00",
-      "longest_outage_hours": null,
-      "shortest_outage_hours": null
+    "KSI-MLA-06": {
+      "total_failures": 5,
+      "total_remediations": 5,
+      "mttr_hours": 26.93,
+      "last_failure": "2025-06-05T23:49:48Z",
+      "retired_pre_cr26": true
     },
-    "KSI-CNA-MAT": {
-      "total_failures": 1,
-      "total_remediations": 0,
-      "mttr_hours": null,
-      "last_failure": "2026-07-06T17:51:14.723954+00:00",
-      "longest_outage_hours": null,
-      "shortest_outage_hours": null
+    "KSI-PIY-05": {
+      "total_failures": 4,
+      "total_remediations": 4,
+      "mttr_hours": 52.88,
+      "last_failure": "2025-10-12T03:08:36.669011Z",
+      "retired_pre_cr26": true
     },
-    "KSI-CNA-RVP": {
-      "total_failures": 1,
-      "total_remediations": 0,
-      "mttr_hours": null,
-      "last_failure": "2026-07-06T17:51:14.723954+00:00",
-      "longest_outage_hours": null,
-      "shortest_outage_hours": null
+    "KSI-PIY-07": {
+      "total_failures": 5,
+      "total_remediations": 5,
+      "mttr_hours": 43.88,
+      "last_failure": "2025-10-12T03:08:36.669011Z",
+      "retired_pre_cr26": true
     },
-    "KSI-IAM-APM": {
-      "total_failures": 1,
-      "total_remediations": 0,
-      "mttr_hours": null,
-      "last_failure": "2026-07-06T17:51:14.723954+00:00",
-      "longest_outage_hours": null,
-      "shortest_outage_hours": null
+    "KSI-TPR-01": {
+      "total_failures": 6,
+      "total_remediations": 6,
+      "mttr_hours": 28.96,
+      "last_failure": "2025-09-25T19:26:49.871705Z",
+      "retired_pre_cr26": true
     },
-    "KSI-IAM-SNU": {
-      "total_failures": 1,
-      "total_remediations": 0,
-      "mttr_hours": null,
-      "last_failure": "2026-07-06T17:51:14.723954+00:00",
-      "longest_outage_hours": null,
-      "shortest_outage_hours": null
+    "KSI-MLA-03": {
+      "total_failures": 3,
+      "total_remediations": 3,
+      "mttr_hours": 31.62,
+      "last_failure": "2025-06-05T05:01:53Z",
+      "retired_pre_cr26": true
     },
-    "KSI-MLA-OSM": {
-      "total_failures": 1,
-      "total_remediations": 0,
-      "mttr_hours": null,
-      "last_failure": "2026-07-06T17:51:14.723954+00:00",
-      "longest_outage_hours": null,
-      "shortest_outage_hours": null
+    "KSI-SVC-07": {
+      "total_failures": 3,
+      "total_remediations": 3,
+      "mttr_hours": 28.03,
+      "last_failure": "2025-06-06T04:21:09.354677Z",
+      "retired_pre_cr26": true
     },
-    "KSI-SCR-MON": {
-      "total_failures": 1,
-      "total_remediations": 1,
-      "mttr_hours": 51.17,
-      "last_failure": "2026-07-06T17:51:14.723954+00:00",
-      "longest_outage_hours": 51.17,
-      "shortest_outage_hours": 51.17
+    "KSI-PIY-02": {
+      "total_failures": 8,
+      "total_remediations": 8,
+      "mttr_hours": 24.43,
+      "last_failure": "2025-12-22T03:23:53.810599Z",
+      "retired_pre_cr26": true
     },
-    "KSI-CMT-RMV": {
-      "total_failures": 1,
-      "total_remediations": 0,
-      "mttr_hours": null,
-      "last_failure": "2026-07-07T21:07:19.254229+00:00",
-      "longest_outage_hours": null,
-      "shortest_outage_hours": null
+    "KSI-SVC-03": {
+      "total_failures": 6,
+      "total_remediations": 6,
+      "mttr_hours": 6.39,
+      "last_failure": "2025-06-06T03:48:06.017208Z",
+      "retired_pre_cr26": true
     },
-    "KSI-CNA-IBP": {
-      "total_failures": 1,
-      "total_remediations": 0,
-      "mttr_hours": null,
-      "last_failure": "2026-07-07T21:07:19.254229+00:00",
-      "longest_outage_hours": null,
-      "shortest_outage_hours": null
+    "KSI-TPR-02": {
+      "total_failures": 4,
+      "total_remediations": 4,
+      "mttr_hours": 16.86,
+      "last_failure": "2025-06-10T18:51:13.351595Z",
+      "retired_pre_cr26": true
+    },
+    "KSI-MLA-04": {
+      "total_failures": 4,
+      "total_remediations": 4,
+      "mttr_hours": 22.8,
+      "last_failure": "2025-06-06T04:21:09.354677Z",
+      "retired_pre_cr26": true
+    },
+    "KSI-CMT-05": {
+      "total_failures": 5,
+      "total_remediations": 5,
+      "mttr_hours": 77.46,
+      "last_failure": "2025-10-14T18:40:19.682172Z",
+      "retired_pre_cr26": true
     }
   }
 }


### PR DESCRIPTION
Syncs the CR26-re-keyed failure tracker (companion backend PR): active failures merged into CR26 IDs with real failure ages preserved (no more double-counted legacy zombies), 452 history entries re-keyed with `legacy_ksi_id` lineage, and 53 pre-CR26-retired indicator entries tagged `retired_pre_cr26`. The failure dashboard now shows a single consistent CR26 timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkTLgdbHAQYrbYMyQmKmPo

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkTLgdbHAQYrbYMyQmKmPo)_