### PR TITLE
Failure register: CR26-keyed tracker sync + retired/lineage badges

### DIFF
--- a/public/data/ksi_failure_tracker.json
+++ b/public/data/ksi_failure_tracker.json
@@ -6843,7 +6843,7 @@
       "duration_hours": 51.17
     },
     {
-      "ksi_id": "KSI-TPR-04",
+      "ksi_id": "KSI-SCR-MON",
       "failed_at": "2026-06-15T21:32:05.248293+00:00",
       "failed_commit": "1a62a92286f219ca7d5e3f8c104d08f3ec39e820",
       "reason": "Not Evaluated: Automatically monitor third party software information resources for upstream vulnerabilities using mechanisms that m... | Not evaluated: circuit breaker engaged before this KSI ran | Verdict: Required operational metric(s) not measured this run: vulnerability_metrics No findings produced for this KSI.",

--- a/src/components/trust/KSIFailureDashboard.jsx
+++ b/src/components/trust/KSIFailureDashboard.jsx
@@ -137,8 +137,12 @@ const DetailDrawer = ({ failure, isActive, onClose, allHistory }) => {
                                 <span className="mono" style={{ fontSize: 17, fontWeight: 600, color: 'var(--indigo)' }}>{failure.ksi_id}</span>
                                 {isActive && sc && <span className="tag warn">{severity}</span>}
                                 {!isActive && <span className="tag ok">RESOLVED</span>}
+                                {failure.retired_pre_cr26 && <span className="tag vi" title="Indicator retired before the FedRAMP Consolidated Rules for 2026; no CR26 successor exists. Historical record.">RETIRED PRE-CR26</span>}
                             </div>
-                            <div className="mono" style={{ fontSize: 11, color: 'var(--ash)', marginTop: 3 }}>{categoryName}</div>
+                            <div className="mono" style={{ fontSize: 11, color: 'var(--ash)', marginTop: 3 }}>
+                                {categoryName}
+                                {failure.legacy_ksi_id && <span style={{ opacity: .7 }}> · formerly {Array.isArray(failure.legacy_ksi_id) ? failure.legacy_ksi_id.join(', ') : failure.legacy_ksi_id}</span>}
+                            </div>
                         </div>
                     </div>
                     {isActive && hoursActive !== null && (


### PR DESCRIPTION
Companion to the backend fix for the July 11 legacy-ID entry:

- **Tracker synced** with the migration-boundary stray re-keyed (`KSI-TPR-04` → `KSI-SCR-MON` with lineage)
- **Failure detail UI** now explains the remaining historical entries instead of leaving them looking stale: a `RETIRED PRE-CR26` badge for indicators retired before the consolidated rules (e.g. `KSI-PIY-02`, `KSI-CMT-05` — no CR26 successor exists), and a "formerly `<legacy id>`" lineage note on re-keyed entries

`npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkTLgdbHAQYrbYMyQmKmPo

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkTLgdbHAQYrbYMyQmKmPo)_